### PR TITLE
IRIs changed

### DIFF
--- a/tensile_test_ontology_TTO/pmdao_TTO.ttl
+++ b/tensile_test_ontology_TTO/pmdao_TTO.ttl
@@ -1,35 +1,30 @@
-@prefix : <http://material-digital.de/pmdco/> .
+@prefix : <http://w3id.org/pmd/co/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix sdo: <http://schema.org/> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@base <http://material-digital.de/pmdao/tto> .
+@base <http://w3id.org/pmd/ao/tto> .
 
-<http://material-digital.de/pmdao/tto> rdf:type owl:Ontology ;
-                                        <http://purl.org/dc/elements/1.1/creator> <http://orcid.org/0000-0001-7192-7143> ,
-                                                                                  <http://orcid.org/0000-0002-3717-7104> ,
-                                                                                  <http://orcid.org/0000-0002-7094-5371> ,
-                                                                                  <http://orcid.org/0000-0002-9014-2920> ;
-                                        <http://purl.org/dc/elements/1.1/title> "Tensile Test Ontology (TTO)"@en ;
-                                        sdo:url "https://github.com/materialdigital/application-ontologies/blob/main/tensile_test_ontology_TTO/pmdao_TTO.ttl"^^xsd:anyURI ;
-                                        owl:versionInfo "1.0"^^xsd:string ;
-                                        <http://www.w3.org/2004/02/skos/core#definition> """This is the stable version of the PMD application ontology (PMDao) of the tensile test (Tensile Test Ontology - TTO) as developed on the basis of the standard ISO 6892-1: Metallic materials - Tensile Testing - Part 1: Method of test at room temperature.
+<http://w3id.org/pmd/ao/tto> rdf:type owl:Ontology ;
+                              <http://purl.org/dc/elements/1.1/creator> <http://orcid.org/0000-0001-7192-7143> ,
+                                                                        <http://orcid.org/0000-0002-3717-7104> ,
+                                                                        <http://orcid.org/0000-0002-7094-5371> ,
+                                                                        <http://orcid.org/0000-0002-9014-2920> ;
+                              <http://purl.org/dc/elements/1.1/title> "Tensile Test Ontology (TTO)"@en ;
+                              sdo:url "http://github.com/materialdigital/application-ontologies/blob/main/tensile_test_ontology_TTO/pmdao_TTO.ttl"^^xsd:anyURI ;
+                              owl:versionInfo "1.0"^^xsd:string ;
+                              <http://www.w3.org/2004/02/skos/core#definition> """This is the stable version of the PMD application ontology (PMDao) of the tensile test (Tensile Test Ontology - TTO) as developed on the basis of the standard ISO 6892-1: Metallic materials - Tensile Testing - Part 1: Method of test at room temperature.
 
 The TTO was developed in the frame of the PMD project. The TTO provides conceptualizations valid for the description of tensile test and corresponding data in accordance with the respective standard. By using TTO for storing tensile test data, all data will be well structured and based on a common vocabulary agreed on by an expert group (generation of FAIR data) which will lead to enhanced data interoperability. This comprises several data categories such as primary data, secondary data and metadata. Data will be human and machine readable. The usage of TTO facilitates data retrieval and downstream usage. Due to a close connection to the mid-level PMD core ontology (PMDco), the interoperability of tensile test data is enhanced and querying in combination with other aspects and data within the broad field of material science and engineering (MSE) is facilitated.
 
 The TTO class structure forms a comprehensible and semantic layer for unified storage of data generated in a tensile test including the possibility to record data from analysis, re-evaluation and re-use. Furthermore, extensive metadata allows to assess data quality and reproduce experiments. Following the open world assumption, object properties are deliberately low restrictive and sparse."""^^xsd:string ;
-                                        <http://www.w3.org/ns/prov#editorialNote> "The tensile test ontology (TTO) was developed in the frame of the joint project of platform material digital (PMD). The TTO is connected to the PMD core ontology (PMDco)."@en .
+                              <http://www.w3.org/ns/prov#editorialNote> "The tensile test ontology (TTO) was developed in the frame of the joint project of platform material digital (PMD). The TTO is connected to the PMD core ontology (PMDco)."@en .
 
 #################################################################
 #    Annotation properties
 #################################################################
-
-###  http://material-digital.de/pmdao/tto/definitionSource
-<http://material-digital.de/pmdao/tto/definitionSource> rdf:type owl:AnnotationProperty ;
-                                                        <http://www.w3.org/2004/02/skos/core#definition> "Indicates the source of the definition."@en .
-
 
 ###  http://purl.org/dc/elements/1.1/creator
 <http://purl.org/dc/elements/1.1/creator> rdf:type owl:AnnotationProperty .
@@ -103,6 +98,11 @@ sdo:url rdf:type owl:AnnotationProperty .
 <http://www.w3.org/ns/prov#sharesDefinitionWith> rdf:type owl:AnnotationProperty .
 
 
+###  http://w3id.org/pmd/ao/tto/definitionSource
+<http://w3id.org/pmd/ao/tto/definitionSource> rdf:type owl:AnnotationProperty ;
+                                               <http://www.w3.org/2004/02/skos/core#definition> "Indicates the source of the definition."@en .
+
+
 #################################################################
 #    Datatypes
 #################################################################
@@ -115,202 +115,9 @@ xsd:float rdf:type rdfs:Datatype .
 #    Object Properties
 #################################################################
 
-###  http://material-digital.de/pmdao/tto/compose
-<http://material-digital.de/pmdao/tto/compose> rdf:type owl:ObjectProperty ;
-                                               owl:inverseOf <http://material-digital.de/pmdao/tto/composedBy> ;
-                                               rdfs:range <http://material-digital.de/pmdao/tto/Object> ;
-                                               rdfs:label "compose"@en ;
-                                               <http://www.w3.org/2004/02/skos/core#definition> "This property is used to describe which objects a voxel or a material contributes to compose."@en .
-
-
-###  http://material-digital.de/pmdao/tto/composedBy
-<http://material-digital.de/pmdao/tto/composedBy> rdf:type owl:ObjectProperty ;
-                                                  rdfs:domain <http://material-digital.de/pmdao/tto/Object> ;
-                                                  rdfs:label "composed by"@en ;
-                                                  <http://www.w3.org/2004/02/skos/core#definition> "This property is used to describe which voxels and materials an object is composed of."@en .
-
-
-###  http://material-digital.de/pmdao/tto/executedBy
-<http://material-digital.de/pmdao/tto/executedBy> rdf:type owl:ObjectProperty ;
-                                                  owl:inverseOf <http://material-digital.de/pmdao/tto/executes> ;
-                                                  rdfs:domain <http://material-digital.de/pmdao/tto/Process> ;
-                                                  rdfs:range <http://material-digital.de/pmdao/tto/ProcessingNode> ;
-                                                  rdfs:label "executed by"@en ;
-                                                  <http://www.w3.org/2004/02/skos/core#definition> "This property represents which process is executed by which process node."@en .
-
-
-###  http://material-digital.de/pmdao/tto/executes
-<http://material-digital.de/pmdao/tto/executes> rdf:type owl:ObjectProperty ;
-                                                rdfs:domain <http://material-digital.de/pmdao/tto/ProcessingNode> ;
-                                                rdfs:range <http://material-digital.de/pmdao/tto/Process> ;
-                                                rdfs:label "execute"@en ;
-                                                <http://www.w3.org/2004/02/skos/core#definition> "This property represents which process node executes a process"@en .
-
-
-###  http://material-digital.de/pmdao/tto/hasCharacteristic
-<http://material-digital.de/pmdao/tto/hasCharacteristic> rdf:type owl:ObjectProperty ;
-                                                         rdfs:subPropertyOf <http://material-digital.de/pmdao/tto/hasParticipant> ;
-                                                         owl:inverseOf <http://material-digital.de/pmdao/tto/isCharacteristicOf> ;
-                                                         rdfs:domain [ rdf:type owl:Class ;
-                                                                       owl:unionOf ( <http://material-digital.de/pmdao/tto/Object>
-                                                                                     <http://material-digital.de/pmdao/tto/Process>
-                                                                                     <http://material-digital.de/pmdao/tto/ProcessingNode>
-                                                                                   )
-                                                                     ] ;
-                                                         rdfs:range <http://material-digital.de/pmdao/tto/ValueObject> ;
-                                                         rdfs:label "has characteristic"@en .
-
-
-###  http://material-digital.de/pmdao/tto/hasComponent
-<http://material-digital.de/pmdao/tto/hasComponent> rdf:type owl:ObjectProperty ;
-                                                    rdfs:domain <http://material-digital.de/pmdao/tto/ProcessingNode> ;
-                                                    rdfs:range <http://material-digital.de/pmdao/tto/ProcessingNode> ;
-                                                    rdfs:label "has component"@en ;
-                                                    <http://www.w3.org/2004/02/skos/core#definition> "An object property associating a process node with its (potentially modular) components, e.g. the chambers of a heat treatment furnace."@en .
-
-
-###  http://material-digital.de/pmdao/tto/hasInput
-<http://material-digital.de/pmdao/tto/hasInput> rdf:type owl:ObjectProperty ;
-                                                rdfs:subPropertyOf <http://material-digital.de/pmdao/tto/hasParticipant> ;
-                                                rdfs:domain [ rdf:type owl:Class ;
-                                                              owl:unionOf ( <http://material-digital.de/pmdao/tto/Process>
-                                                                            <http://material-digital.de/pmdao/tto/ProcessingNode>
-                                                                          )
-                                                            ] ;
-                                                rdfs:range <http://material-digital.de/pmdao/tto/Object> ;
-                                                rdfs:label "has input"@en ;
-                                                <http://www.w3.org/2004/02/skos/core#definition> "This property is used to link the processes to their input objects"@en .
-
-
-###  http://material-digital.de/pmdao/tto/hasNextProcess
-<http://material-digital.de/pmdao/tto/hasNextProcess> rdf:type owl:ObjectProperty ;
-                                                      owl:inverseOf <http://material-digital.de/pmdao/tto/hasPreviousProcess> ;
-                                                      rdfs:domain <http://material-digital.de/pmdao/tto/Process> ;
-                                                      rdfs:range <http://material-digital.de/pmdao/tto/Process> ;
-                                                      rdfs:label "has next process"@en ;
-                                                      <http://www.w3.org/2004/02/skos/core#definition> "This property is used to indicate the process that was run after the current process."@en .
-
-
-###  http://material-digital.de/pmdao/tto/hasOutput
-<http://material-digital.de/pmdao/tto/hasOutput> rdf:type owl:ObjectProperty ;
-                                                 rdfs:subPropertyOf <http://material-digital.de/pmdao/tto/hasParticipant> ;
-                                                 owl:inverseOf <http://material-digital.de/pmdao/tto/isOutputOf> ;
-                                                 rdfs:domain [ rdf:type owl:Class ;
-                                                               owl:unionOf ( <http://material-digital.de/pmdao/tto/Process>
-                                                                             <http://material-digital.de/pmdao/tto/ProcessingNode>
-                                                                           )
-                                                             ] ;
-                                                 rdfs:range <http://material-digital.de/pmdao/tto/Object> ;
-                                                 rdfs:label "has output"@en ;
-                                                 <http://www.w3.org/2004/02/skos/core#definition> "This property is used to link the processes to their output objects"@en .
-
-
-###  http://material-digital.de/pmdao/tto/hasParticipant
-<http://material-digital.de/pmdao/tto/hasParticipant> rdf:type owl:ObjectProperty ;
-                                                      owl:equivalentProperty <http://purl.obolibrary.org/obo/RO_0000057> ;
-                                                      owl:inverseOf <http://material-digital.de/pmdao/tto/isParticipantOf> ;
-                                                      rdfs:label "has participant"@en ;
-                                                      <http://www.w3.org/2004/02/skos/core#definition> """A similar idea of the BFOs hasParticipant 
-
-... to be refined"""@en .
-
-
-###  http://material-digital.de/pmdao/tto/hasPreviousProcess
-<http://material-digital.de/pmdao/tto/hasPreviousProcess> rdf:type owl:ObjectProperty ;
-                                                          rdfs:domain <http://material-digital.de/pmdao/tto/Process> ;
-                                                          rdfs:range <http://material-digital.de/pmdao/tto/Process> ;
-                                                          rdfs:label "has previous process"@en ;
-                                                          <http://www.w3.org/2004/02/skos/core#definition> "This property is used to indicate that which process was previously run."@en .
-
-
-###  http://material-digital.de/pmdao/tto/hasProcess
-<http://material-digital.de/pmdao/tto/hasProcess> rdf:type owl:ObjectProperty ;
-                                                  rdfs:domain <http://material-digital.de/pmdao/tto/Project> ;
-                                                  rdfs:range <http://material-digital.de/pmdao/tto/Process> ;
-                                                  rdfs:label "has process"@en .
-
-
-###  http://material-digital.de/pmdao/tto/hasResource
-<http://material-digital.de/pmdao/tto/hasResource> rdf:type owl:ObjectProperty ;
-                                                   rdfs:domain <http://material-digital.de/pmdao/tto/ValueObject> ;
-                                                   rdfs:label "has resource"@en .
-
-
-###  http://material-digital.de/pmdao/tto/hasState
-<http://material-digital.de/pmdao/tto/hasState> rdf:type owl:ObjectProperty ;
-                                                rdfs:domain [ rdf:type owl:Class ;
-                                                              owl:unionOf ( <http://material-digital.de/pmdao/tto/Specimen>
-                                                                            <http://material-digital.de/pmdao/tto/TestPiece>
-                                                                          )
-                                                            ] ;
-                                                rdfs:label "has state"@en .
-
-
-###  http://material-digital.de/pmdao/tto/hasSubordinateProcess
-<http://material-digital.de/pmdao/tto/hasSubordinateProcess> rdf:type owl:ObjectProperty ;
-                                                             rdfs:domain <http://material-digital.de/pmdao/tto/Process> ;
-                                                             rdfs:range <http://material-digital.de/pmdao/tto/Process> ;
-                                                             rdfs:label "has subordinate process"@en ;
-                                                             <http://www.w3.org/2004/02/skos/core#definition> "This property is used to link a process to its subordinate processes."@en .
-
-
-###  http://material-digital.de/pmdao/tto/hasUnit
-<http://material-digital.de/pmdao/tto/hasUnit> rdf:type owl:ObjectProperty ;
-                                               rdfs:domain <http://material-digital.de/pmdao/tto/ValueObject> ;
-                                               rdfs:label "has unit"@en ;
-                                               <http://www.w3.org/2004/02/skos/core#definition> """Unit of measurement.
-Examples for rdsf:range are units from qudt or wikidata or own defindes units."""@en .
-
-
-###  http://material-digital.de/pmdao/tto/isCharacteristicOf
-<http://material-digital.de/pmdao/tto/isCharacteristicOf> rdf:type owl:ObjectProperty ;
-                                                          rdfs:subPropertyOf <http://material-digital.de/pmdao/tto/isParticipantOf> ;
-                                                          rdfs:label "is characteristic of"@en .
-
-
-###  http://material-digital.de/pmdao/tto/isInputOf
-<http://material-digital.de/pmdao/tto/isInputOf> rdf:type owl:ObjectProperty ;
-                                                 rdfs:subPropertyOf <http://material-digital.de/pmdao/tto/isParticipantOf> ;
-                                                 owl:inverseOf <http://material-digital.de/pmdao/tto/isInputOf> ;
-                                                 rdfs:label "is input of"@en .
-
-
-###  http://material-digital.de/pmdao/tto/isOutputOf
-<http://material-digital.de/pmdao/tto/isOutputOf> rdf:type owl:ObjectProperty ;
-                                                  rdfs:subPropertyOf <http://material-digital.de/pmdao/tto/isParticipantOf> ;
-                                                  rdfs:label "is output of"@en .
-
-
-###  http://material-digital.de/pmdao/tto/isParticipantOf
-<http://material-digital.de/pmdao/tto/isParticipantOf> rdf:type owl:ObjectProperty ;
-                                                       rdfs:subPropertyOf owl:topObjectProperty ;
-                                                       rdfs:label "is participant of"@en .
-
-
-###  http://material-digital.de/pmdao/tto/relatesTo
-<http://material-digital.de/pmdao/tto/relatesTo> rdf:type owl:ObjectProperty ;
-                                                 rdfs:domain <http://material-digital.de/pmdao/tto/ValueObject> ;
-                                                 rdfs:label "relates to"@en .
-
-
-###  http://material-digital.de/pmdao/tto/relatesToElement
-<http://material-digital.de/pmdao/tto/relatesToElement> rdf:type owl:ObjectProperty ;
-                                                        rdfs:subPropertyOf <http://material-digital.de/pmdao/tto/relatesTo> ;
-                                                        rdfs:domain <http://material-digital.de/pmdao/tto/ChemicalObject> ;
-                                                        rdfs:range <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-                                                        rdfs:label "relates to element"@en .
-
-
-###  http://material-digital.de/pmdao/tto/relatesToExtension
-<http://material-digital.de/pmdao/tto/relatesToExtension> rdf:type owl:ObjectProperty ;
-                                                          rdfs:subPropertyOf <http://material-digital.de/pmdao/tto/relatesTo> ;
-                                                          rdfs:domain <http://material-digital.de/pmdao/tto/ProofStrengthPlasticExtension> ;
-                                                          rdfs:range <http://material-digital.de/pmdao/tto/PercentageExtension> ;
-                                                          rdfs:label "relates to extension"@en .
-
-
 ###  http://purl.obolibrary.org/obo/RO_0000057
 <http://purl.obolibrary.org/obo/RO_0000057> rdf:type owl:ObjectProperty ;
+                                            owl:equivalentProperty <http://w3id.org/pmd/ao/tto/hasParticipant> ;
                                             rdfs:label "has participant"@en .
 
 
@@ -343,16 +150,202 @@ Examples for rdsf:range are units from qudt or wikidata or own defindes units.""
                                             <http://www.w3.org/2004/02/skos/core#definition> "Attribution is the ascribing of an entity to an agent."@en .
 
 
+###  http://w3id.org/pmd/ao/tto/compose
+<http://w3id.org/pmd/ao/tto/compose> rdf:type owl:ObjectProperty ;
+                                      owl:inverseOf <http://w3id.org/pmd/ao/tto/composedBy> ;
+                                      rdfs:range <http://w3id.org/pmd/ao/tto/Object> ;
+                                      rdfs:label "compose"@en ;
+                                      <http://www.w3.org/2004/02/skos/core#definition> "This property is used to describe which objects a voxel or a material contributes to compose."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/composedBy
+<http://w3id.org/pmd/ao/tto/composedBy> rdf:type owl:ObjectProperty ;
+                                         rdfs:domain <http://w3id.org/pmd/ao/tto/Object> ;
+                                         rdfs:label "composed by"@en ;
+                                         <http://www.w3.org/2004/02/skos/core#definition> "This property is used to describe which voxels and materials an object is composed of."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/executedBy
+<http://w3id.org/pmd/ao/tto/executedBy> rdf:type owl:ObjectProperty ;
+                                         owl:inverseOf <http://w3id.org/pmd/ao/tto/executes> ;
+                                         rdfs:domain <http://w3id.org/pmd/ao/tto/Process> ;
+                                         rdfs:range <http://w3id.org/pmd/ao/tto/ProcessingNode> ;
+                                         rdfs:label "executed by"@en ;
+                                         <http://www.w3.org/2004/02/skos/core#definition> "This property represents which process is executed by which process node."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/executes
+<http://w3id.org/pmd/ao/tto/executes> rdf:type owl:ObjectProperty ;
+                                       rdfs:domain <http://w3id.org/pmd/ao/tto/ProcessingNode> ;
+                                       rdfs:range <http://w3id.org/pmd/ao/tto/Process> ;
+                                       rdfs:label "execute"@en ;
+                                       <http://www.w3.org/2004/02/skos/core#definition> "This property represents which process node executes a process"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/hasCharacteristic
+<http://w3id.org/pmd/ao/tto/hasCharacteristic> rdf:type owl:ObjectProperty ;
+                                                rdfs:subPropertyOf <http://w3id.org/pmd/ao/tto/hasParticipant> ;
+                                                owl:inverseOf <http://w3id.org/pmd/ao/tto/isCharacteristicOf> ;
+                                                rdfs:domain [ rdf:type owl:Class ;
+                                                              owl:unionOf ( <http://w3id.org/pmd/ao/tto/Object>
+                                                                            <http://w3id.org/pmd/ao/tto/Process>
+                                                                            <http://w3id.org/pmd/ao/tto/ProcessingNode>
+                                                                          )
+                                                            ] ;
+                                                rdfs:range <http://w3id.org/pmd/ao/tto/ValueObject> ;
+                                                rdfs:label "has characteristic"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/hasComponent
+<http://w3id.org/pmd/ao/tto/hasComponent> rdf:type owl:ObjectProperty ;
+                                           rdfs:domain <http://w3id.org/pmd/ao/tto/ProcessingNode> ;
+                                           rdfs:range <http://w3id.org/pmd/ao/tto/ProcessingNode> ;
+                                           rdfs:label "has component"@en ;
+                                           <http://www.w3.org/2004/02/skos/core#definition> "An object property associating a process node with its (potentially modular) components, e.g. the chambers of a heat treatment furnace."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/hasInput
+<http://w3id.org/pmd/ao/tto/hasInput> rdf:type owl:ObjectProperty ;
+                                       rdfs:subPropertyOf <http://w3id.org/pmd/ao/tto/hasParticipant> ;
+                                       rdfs:domain [ rdf:type owl:Class ;
+                                                     owl:unionOf ( <http://w3id.org/pmd/ao/tto/Process>
+                                                                   <http://w3id.org/pmd/ao/tto/ProcessingNode>
+                                                                 )
+                                                   ] ;
+                                       rdfs:range <http://w3id.org/pmd/ao/tto/Object> ;
+                                       rdfs:label "has input"@en ;
+                                       <http://www.w3.org/2004/02/skos/core#definition> "This property is used to link the processes to their input objects"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/hasNextProcess
+<http://w3id.org/pmd/ao/tto/hasNextProcess> rdf:type owl:ObjectProperty ;
+                                             owl:inverseOf <http://w3id.org/pmd/ao/tto/hasPreviousProcess> ;
+                                             rdfs:domain <http://w3id.org/pmd/ao/tto/Process> ;
+                                             rdfs:range <http://w3id.org/pmd/ao/tto/Process> ;
+                                             rdfs:label "has next process"@en ;
+                                             <http://www.w3.org/2004/02/skos/core#definition> "This property is used to indicate the process that was run after the current process."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/hasOutput
+<http://w3id.org/pmd/ao/tto/hasOutput> rdf:type owl:ObjectProperty ;
+                                        rdfs:subPropertyOf <http://w3id.org/pmd/ao/tto/hasParticipant> ;
+                                        owl:inverseOf <http://w3id.org/pmd/ao/tto/isOutputOf> ;
+                                        rdfs:domain [ rdf:type owl:Class ;
+                                                      owl:unionOf ( <http://w3id.org/pmd/ao/tto/Process>
+                                                                    <http://w3id.org/pmd/ao/tto/ProcessingNode>
+                                                                  )
+                                                    ] ;
+                                        rdfs:range <http://w3id.org/pmd/ao/tto/Object> ;
+                                        rdfs:label "has output"@en ;
+                                        <http://www.w3.org/2004/02/skos/core#definition> "This property is used to link the processes to their output objects"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/hasParticipant
+<http://w3id.org/pmd/ao/tto/hasParticipant> rdf:type owl:ObjectProperty ;
+                                             owl:inverseOf <http://w3id.org/pmd/ao/tto/isParticipantOf> ;
+                                             rdfs:label "has participant"@en ;
+                                             <http://www.w3.org/2004/02/skos/core#definition> """A similar idea of the BFOs hasParticipant 
+
+... to be refined"""@en .
+
+
+###  http://w3id.org/pmd/ao/tto/hasPreviousProcess
+<http://w3id.org/pmd/ao/tto/hasPreviousProcess> rdf:type owl:ObjectProperty ;
+                                                 rdfs:domain <http://w3id.org/pmd/ao/tto/Process> ;
+                                                 rdfs:range <http://w3id.org/pmd/ao/tto/Process> ;
+                                                 rdfs:label "has previous process"@en ;
+                                                 <http://www.w3.org/2004/02/skos/core#definition> "This property is used to indicate that which process was previously run."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/hasProcess
+<http://w3id.org/pmd/ao/tto/hasProcess> rdf:type owl:ObjectProperty ;
+                                         rdfs:domain <http://w3id.org/pmd/ao/tto/Project> ;
+                                         rdfs:range <http://w3id.org/pmd/ao/tto/Process> ;
+                                         rdfs:label "has process"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/hasResource
+<http://w3id.org/pmd/ao/tto/hasResource> rdf:type owl:ObjectProperty ;
+                                          rdfs:domain <http://w3id.org/pmd/ao/tto/ValueObject> ;
+                                          rdfs:label "has resource"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/hasState
+<http://w3id.org/pmd/ao/tto/hasState> rdf:type owl:ObjectProperty ;
+                                       rdfs:domain [ rdf:type owl:Class ;
+                                                     owl:unionOf ( <http://w3id.org/pmd/ao/tto/Specimen>
+                                                                   <http://w3id.org/pmd/ao/tto/TestPiece>
+                                                                 )
+                                                   ] ;
+                                       rdfs:label "has state"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/hasSubordinateProcess
+<http://w3id.org/pmd/ao/tto/hasSubordinateProcess> rdf:type owl:ObjectProperty ;
+                                                    rdfs:domain <http://w3id.org/pmd/ao/tto/Process> ;
+                                                    rdfs:range <http://w3id.org/pmd/ao/tto/Process> ;
+                                                    rdfs:label "has subordinate process"@en ;
+                                                    <http://www.w3.org/2004/02/skos/core#definition> "This property is used to link a process to its subordinate processes."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/hasUnit
+<http://w3id.org/pmd/ao/tto/hasUnit> rdf:type owl:ObjectProperty ;
+                                      rdfs:domain <http://w3id.org/pmd/ao/tto/ValueObject> ;
+                                      rdfs:label "has unit"@en ;
+                                      <http://www.w3.org/2004/02/skos/core#definition> """Unit of measurement.
+Examples for rdsf:range are units from qudt or wikidata or own defindes units."""@en .
+
+
+###  http://w3id.org/pmd/ao/tto/isCharacteristicOf
+<http://w3id.org/pmd/ao/tto/isCharacteristicOf> rdf:type owl:ObjectProperty ;
+                                                 rdfs:subPropertyOf <http://w3id.org/pmd/ao/tto/isParticipantOf> ;
+                                                 rdfs:label "is characteristic of"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/isInputOf
+<http://w3id.org/pmd/ao/tto/isInputOf> rdf:type owl:ObjectProperty ;
+                                        rdfs:subPropertyOf <http://w3id.org/pmd/ao/tto/isParticipantOf> ;
+                                        owl:inverseOf <http://w3id.org/pmd/ao/tto/isInputOf> ;
+                                        rdfs:label "is input of"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/isOutputOf
+<http://w3id.org/pmd/ao/tto/isOutputOf> rdf:type owl:ObjectProperty ;
+                                         rdfs:subPropertyOf <http://w3id.org/pmd/ao/tto/isParticipantOf> ;
+                                         rdfs:label "is output of"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/isParticipantOf
+<http://w3id.org/pmd/ao/tto/isParticipantOf> rdf:type owl:ObjectProperty ;
+                                              rdfs:subPropertyOf owl:topObjectProperty ;
+                                              rdfs:label "is participant of"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/relatesTo
+<http://w3id.org/pmd/ao/tto/relatesTo> rdf:type owl:ObjectProperty ;
+                                        rdfs:domain <http://w3id.org/pmd/ao/tto/ValueObject> ;
+                                        rdfs:label "relates to"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/relatesToElement
+<http://w3id.org/pmd/ao/tto/relatesToElement> rdf:type owl:ObjectProperty ;
+                                               rdfs:subPropertyOf <http://w3id.org/pmd/ao/tto/relatesTo> ;
+                                               rdfs:domain <http://w3id.org/pmd/ao/tto/ChemicalObject> ;
+                                               rdfs:range <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+                                               rdfs:label "relates to element"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/relatesToExtension
+<http://w3id.org/pmd/ao/tto/relatesToExtension> rdf:type owl:ObjectProperty ;
+                                                 rdfs:subPropertyOf <http://w3id.org/pmd/ao/tto/relatesTo> ;
+                                                 rdfs:domain <http://w3id.org/pmd/ao/tto/ProofStrengthPlasticExtension> ;
+                                                 rdfs:range <http://w3id.org/pmd/ao/tto/PercentageExtension> ;
+                                                 rdfs:label "relates to extension"@en .
+
+
 #################################################################
 #    Data properties
 #################################################################
-
-###  http://material-digital.de/pmdao/tto/hasValue
-<http://material-digital.de/pmdao/tto/hasValue> rdf:type owl:DatatypeProperty ;
-                                                rdfs:domain <http://material-digital.de/pmdao/tto/ValueObject> ;
-                                                rdfs:range rdfs:Literal ;
-                                                rdfs:label "has value"@en .
-
 
 ###  http://qudt.org/schema/qudt/lowerBound
 <http://qudt.org/schema/qudt/lowerBound> rdf:type owl:DatatypeProperty .
@@ -400,2294 +393,22 @@ Examples for rdsf:range are units from qudt or wikidata or own defindes units.""
                                                                                     <http://www.w3.org/ns/prov#atTime> .
 
 
+###  http://w3id.org/pmd/ao/tto/hasValue
+<http://w3id.org/pmd/ao/tto/hasValue> rdf:type owl:DatatypeProperty ;
+                                       rdfs:domain <http://w3id.org/pmd/ao/tto/ValueObject> ;
+                                       rdfs:range rdfs:Literal ;
+                                       rdfs:label "has value"@en .
+
+
 #################################################################
 #    Classes
 #################################################################
 
-###  http://material-digital.de/pmdao/tto/AccreditationDocument
-<http://material-digital.de/pmdao/tto/AccreditationDocument> rdf:type owl:Class ;
-                                                             rdfs:subClassOf <http://material-digital.de/pmdao/tto/Document> ;
-                                                             <http://material-digital.de/pmdao/tto/definitionSource> "http://www.merriam-webster.com/dictionary/accreditation"@en ;
-                                                             rdfs:label "Accreditation Document"@en ,
-                                                                        "Akkreditierungsdokument"@de ;
-                                                             <http://www.w3.org/2004/02/skos/core#definition> "Diese Entität beschreibt ein Dokument, welches aussagt, dass einer Organisation, Person oder Einrichtung eine offizielle Konformität mit einer Norm anerkannt wurde. Dies kann z. B. Prozesse, Ausrüstungen oder ganze Laboratorien umfassen."@de ,
-                                                                                                              "This entity describes a document used to state that an official authorization or approval to recognize or vouch for a conformation with a standard was granted to an organization, person, or entity. This may include, e.g., processes, (sets of) equipment, or entire laboratories."@en .
-
-
-###  http://material-digital.de/pmdao/tto/Acoustical
-<http://material-digital.de/pmdao/tto/Acoustical> rdf:type owl:Class ;
-                                                  rdfs:subClassOf <http://material-digital.de/pmdao/tto/MaterialProperty> ;
-                                                  <http://material-digital.de/pmdao/tto/definitionSource> "“Acoustic.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/acoustic. Accessed 13 Jan. 2023."@en ;
-                                                  rdfs:label "Acoustical"@en ,
-                                                             "Akustisch"@de ;
-                                                  <http://www.w3.org/2004/02/skos/core#definition> "Acoustical is relating to the sense or organs of hearing, to sound, or to the science of sounds. Here specifically on the acoustic properties of a material."@en ,
-                                                                                                   "Akustisch bezieht sich auf den Hörsinn oder die Hörorgane, auf Schall oder auf die Wissenschaft vom Schall. Hier spezifisch auf die akustischen Eigenschaften eines Materials."@de .
-
-
-###  http://material-digital.de/pmdao/tto/Address
-<http://material-digital.de/pmdao/tto/Address> rdf:type owl:Class ;
-                                               rdfs:subClassOf <http://material-digital.de/pmdao/tto/ValueObject> ;
-                                               <http://material-digital.de/pmdao/tto/definitionSource> "“Address.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/address. Accessed 16 Jan. 2023."@en ;
-                                               rdfs:label "Address"@en ,
-                                                          "Adresse"@de ;
-                                               <http://www.w3.org/2004/02/skos/core#definition> "A place where a person or organization may be communicated with."@en ,
-                                                                                                "Ein Ort, an dem mit einer Person oder Organisation kommuniziert werden kann."@de .
-
-
-###  http://material-digital.de/pmdao/tto/AgingInterval
-<http://material-digital.de/pmdao/tto/AgingInterval> rdf:type owl:Class ;
-                                                     rdfs:subClassOf <http://material-digital.de/pmdao/tto/AgingTime> ;
-                                                     rdfs:label "Aging Interval"@en ,
-                                                                "Alterungsintervall"@de ;
-                                                     <http://www.w3.org/2004/02/skos/core#definition> "Timespan a Temperature during  an Aging Process is hold."@en .
-
-
-###  http://material-digital.de/pmdao/tto/AgingProcess
-<http://material-digital.de/pmdao/tto/AgingProcess> rdf:type owl:Class ;
-                                                    rdfs:subClassOf <http://material-digital.de/pmdao/tto/Process> ;
-                                                    rdfs:label "Aging Process"@en ,
-                                                               "Alterungsprozess"@de ;
-                                                    <http://www.w3.org/2004/02/skos/core#definition> "Das Aging oder Auslagern ist ein Anlassvorgang, der den Martensit (Härtungsgefüge) wieder duktil und verformbar macht. Dabei wird ein Agingvorgang genutzt, nämlich die Bildung von Ausscheidungen in Form von FeXCY - Carbiden"@de ,
-                                                                                                     "The process of hardening an alloy by a method that causes a constituent to precipitate from solid solution."@en ;
-                                                    <http://www.w3.org/2004/02/skos/core#example> "The Process of austenitizing and quenching a steel alloy to achieve a martensitic microstructure for hardness increase."@en .
-
-
-###  http://material-digital.de/pmdao/tto/AgingTemperature
-<http://material-digital.de/pmdao/tto/AgingTemperature> rdf:type owl:Class ;
-                                                        rdfs:subClassOf <http://material-digital.de/pmdao/tto/Temperature> ;
-                                                        rdfs:label "Aging Temperature"@en ,
-                                                                   "Alterungstemperatur"@de ;
-                                                        <http://www.w3.org/2004/02/skos/core#definition> "Variable Temperature during an Aging Process depending on the desired deposition formations."@en .
-
-
-###  http://material-digital.de/pmdao/tto/AgingTime
-<http://material-digital.de/pmdao/tto/AgingTime> rdf:type owl:Class ;
-                                                 rdfs:subClassOf <http://material-digital.de/pmdao/tto/Time> ;
-                                                 rdfs:label "Aging Time"@en ,
-                                                            "Alterungszeit"@de ;
-                                                 <http://www.w3.org/2004/02/skos/core#definition> "The timespan that an Aging Process executes to completion."@en .
-
-
-###  http://material-digital.de/pmdao/tto/Algorithm
-<http://material-digital.de/pmdao/tto/Algorithm> rdf:type owl:Class ;
-                                                 rdfs:subClassOf <http://material-digital.de/pmdao/tto/Method> ;
-                                                 <http://material-digital.de/pmdao/tto/definitionSource> "“Algorithm.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/algorithm. Accessed 24 Nov. 2022."@en ;
-                                                 rdfs:label "Algorithm"@en ,
-                                                            "Algorithmus"@de ;
-                                                 <http://www.w3.org/2004/02/skos/core#definition> "A procedure for solving a mathematical problem (as of finding the greatest common divisor) in a finite number of steps that frequently involves repetition of an operation."@en .
-
-
-###  http://material-digital.de/pmdao/tto/AmorphousStructure
-<http://material-digital.de/pmdao/tto/AmorphousStructure> rdf:type owl:Class ;
-                                                          rdfs:subClassOf <http://material-digital.de/pmdao/tto/MaterialStructure> ;
-                                                          <http://material-digital.de/pmdao/tto/definitionSource> "“Amorphous solid - Structure.” Wikipedia The Free Encyclopedia, http://en.wikipedia.org/wiki/Amorphous_solid. Accessed 13 Jan. 2023."@en ;
-                                                          rdfs:label "Amorphe Struktur"@de ,
-                                                                     "Amorphous Structure"@en ;
-                                                          <http://www.w3.org/2004/02/skos/core#definition> "Amorphe Materialien haben eine innere Struktur, die aus miteinander verbundenen Strukturblöcken besteht, die den grundlegenden Struktureinheiten in der entsprechenden kristallinen Phase der gleichen Verbindung ähnlich sein können. Anders als bei kristallinen Materialien besteht jedoch keine langfristige Ordnung. Amorphe Materialien können daher nicht durch eine bestimmte Einheitszelle definiert werden. "@de ,
-                                                                                                           "Amorphous materials have an internal structure consisting of interconnected structural blocks that can be similar to the basic structural units found in the corresponding crystalline phase of the same compound. Unlike in crystalline materials, however, no long-range order exists. Amorphous materials therefore cannot be defined by a finite unit cell. "@en .
-
-
-###  http://material-digital.de/pmdao/tto/AnalysingProcess
-<http://material-digital.de/pmdao/tto/AnalysingProcess> rdf:type owl:Class ;
-                                                        rdfs:subClassOf <http://material-digital.de/pmdao/tto/Process> ;
-                                                        rdfs:label "Analyseprozess"@de ,
-                                                                   "Analysing Process"@en ;
-                                                        <http://www.w3.org/2004/02/skos/core#definition> """A process that is driven by the primary intent to gain new measurements
-An analysis process is either a transformative process or a non-transformative process."""@en .
-
-
-###  http://material-digital.de/pmdao/tto/Area
-<http://material-digital.de/pmdao/tto/Area> rdf:type owl:Class ;
-                                            rdfs:subClassOf <http://material-digital.de/pmdao/tto/ValueObject> ;
-                                            rdfs:label "Area"@en ,
-                                                       "Fläche"@de ;
-                                            <http://www.w3.org/2004/02/skos/core#definition> "The extent or measurement of a surface."@en .
-
-
-###  http://material-digital.de/pmdao/tto/AssemblingProcess
-<http://material-digital.de/pmdao/tto/AssemblingProcess> rdf:type owl:Class ;
-                                                         rdfs:subClassOf <http://material-digital.de/pmdao/tto/Process> ;
-                                                         rdfs:label "Assemblierungsprozess"@de ,
-                                                                    "Assembling Process"@en ;
-                                                         <http://www.w3.org/2004/02/skos/core#definition> "A process to mount or demount a component."@en .
-
-
-###  http://material-digital.de/pmdao/tto/BaseMaterial
-<http://material-digital.de/pmdao/tto/BaseMaterial> rdf:type owl:Class ;
-                                                    rdfs:subClassOf <http://material-digital.de/pmdao/tto/EngineeredMaterial> ;
-                                                    rdfs:label "Ausgangsmaterial"@de ,
-                                                               "Base Material"@en ;
-                                                    <http://www.w3.org/2004/02/skos/core#definition> "Diese Entität wird verwendet, um ein Material zu beschreiben, das als solches gegeben angenommen und am Anfang einer betrachteten Prozesskette verwendet wurde."@de ,
-                                                                                                     "This entity is used to describe the material that was taken as granted as such and used in the beginning of a process chain under consideration."@en .
-
-
-###  http://material-digital.de/pmdao/tto/Biological
-<http://material-digital.de/pmdao/tto/Biological> rdf:type owl:Class ;
-                                                  rdfs:subClassOf <http://material-digital.de/pmdao/tto/MaterialProperty> ;
-                                                  <http://material-digital.de/pmdao/tto/definitionSource> "“Biological.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/biological. Accessed 13 Jan. 2023."@en ;
-                                                  rdfs:label "Biological"@en ,
-                                                             "Biologisch"@de ;
-                                                  <http://www.w3.org/2004/02/skos/core#definition> "Biological is relating to biology or to life and living processes. Here specifically to the biological properties of a material."@en ,
-                                                                                                   "Biologisch bezieht sich auf die Biologie oder auf das Leben und lebende Prozesse. Hier speziell auf die biologischen Eigenschaften eines Materials."@de .
-
-
-###  http://material-digital.de/pmdao/tto/Blank
-<http://material-digital.de/pmdao/tto/Blank> rdf:type owl:Class ;
-                                             rdfs:subClassOf <http://material-digital.de/pmdao/tto/EngineeredMaterial> ;
-                                             <http://material-digital.de/pmdao/tto/definitionSource> "“Blank.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/blank. Accessed 25 Nov. 2022."@en ;
-                                             rdfs:label "Blank"@en ,
-                                                        "Rohling"@de ;
-                                             <http://www.w3.org/2004/02/skos/core#definition> "A piece of material prepared to be made into something by a further operation."@en .
-
-
-###  http://material-digital.de/pmdao/tto/BondingType
-<http://material-digital.de/pmdao/tto/BondingType> rdf:type owl:Class ;
-                                                   rdfs:subClassOf <http://material-digital.de/pmdao/tto/MaterialRelated> ;
-                                                   <http://material-digital.de/pmdao/tto/definitionSource> "\"Bond types.” American Heritage® Dictionary of the English Language, Fifth Edition, http://www.thefreedictionary.com/Bond+Types. Accessed 13 Jan. 2023."@en ;
-                                                   rdfs:label "Bindungstyp"@de ,
-                                                              "BondingType"@en ;
-                                                   <http://www.w3.org/2004/02/skos/core#definition> "Any of several forces, especially the ionic bond, covalent bond, and metallic bond, by which atoms or ions are bound in a molecule or crystal."@en ,
-                                                                                                    "Eine von mehreren Bindungen, insbesondere die Ionenbindung, die kovalente Bindung und die Metallbindung, durch die Atome oder Ionen in einem Molekül oder Kristall gebunden sind."@de .
-
-
-###  http://material-digital.de/pmdao/tto/CalibrationDocument
-<http://material-digital.de/pmdao/tto/CalibrationDocument> rdf:type owl:Class ;
-                                                           rdfs:subClassOf <http://material-digital.de/pmdao/tto/Document> ;
-                                                           <http://material-digital.de/pmdao/tto/definitionSource> "http://www.merriam-webster.com/dictionary/calibration"@en ;
-                                                           rdfs:label "Calibration Document"@en ,
-                                                                      "Kalibrierschein"@de ,
-                                                                      "Kalibrierungsdokument"@de ;
-                                                           <http://www.w3.org/2004/02/skos/core#definition> "Diese Entität beschreibt ein Dokument, welches Abweichungen eines Messgerätes oder einer Maßverkörperung gegenüber einem anderen Gerät oder einer anderen Maßverkörperung feststellt und dokumentiert. Typischerweise ist die Person, welche die Kalibrierung durchführte, angegeben."@de ,
-                                                                                                            "This entity describes a document used to state that a set of graduations to indicate values or positions has been performed. Typically, the calibration operator is included."@en .
-
-
-###  http://material-digital.de/pmdao/tto/CalibrationRange
-<http://material-digital.de/pmdao/tto/CalibrationRange> rdf:type owl:Class ;
-                                                        rdfs:subClassOf <http://material-digital.de/pmdao/tto/ValueObject> ;
-                                                        rdfs:label "Calibration range"@en ,
-                                                                   "Kalibrierbereich"@de ;
-                                                        <http://www.w3.org/2004/02/skos/core#definition> "Diese Eigenschaft beschreibt den Bereich zwischen den Grenzen, innerhalb derer eine Größe gemessen, empfangen oder übertragen wird (typischerweise von einem Prozessknoten, z. B. einer Maschine), ausgedrückt durch die Angabe des unteren und oberen Bereichswertes."@de ,
-                                                                                                         "This property describes the region between the limits within which a quantity is measured, received or transmitted (typically by a process node, e.g. a machine), expressed by stating the lower and upper range values."@en .
-
-
-###  http://material-digital.de/pmdao/tto/Caliper
-<http://material-digital.de/pmdao/tto/Caliper> rdf:type owl:Class ;
-                                               rdfs:subClassOf <http://material-digital.de/pmdao/tto/MeasuringDevice> ;
-                                               <http://material-digital.de/pmdao/tto/definitionSource> "http://www.merriam-webster.com/dictionary/caliper"@en ;
-                                               rdfs:label "Caliper"@en ,
-                                                          "Messschieber"@de ;
-                                               <http://www.w3.org/2004/02/skos/core#definition> "any of various measuring instruments having two usually adjustable arms, legs, or jaws used especially to measure the dimensions of objects, such as diameters or thicknesses"@en ,
-                                                                                                "ein Messgerät mit zwei in der Regel verstellbaren Armen, Schenkeln oder Klemmbacken, das vor allem zur Messung der Abmessungen von Gegenständen, wie z. B. des Durchmessers oder der Dicke, verwendet wird"@de .
-
-
-###  http://material-digital.de/pmdao/tto/ChangeOfTransverseDimension
-<http://material-digital.de/pmdao/tto/ChangeOfTransverseDimension> rdf:type owl:Class ;
-                                                                   rdfs:subClassOf <http://material-digital.de/pmdao/tto/Length> ;
-                                                                   <http://material-digital.de/pmdao/tto/definitionSource> "DIN EN ISO 10113:2021-06" ;
-                                                                   rdfs:label "Change Of Transverse Dimension"@en ,
-                                                                              "Änderung der transversalen Dimension"@de ;
-                                                                   <http://www.w3.org/2004/02/skos/core#definition> "Dieses Wertobjekt beschreibt eine Variation der Abmessungen eines Prüfkörpers in Bezug auf seine Querachse, die sich auf seine Querschnittsfläche auswirkt und möglicherweise während eines Zugversuchs auftritt. Das Verhältnis der wahren plastischen Breitendehnung und der wahren plastischen Dickendehnung in einem in uniaxialem Zug beanspruchten Prüfkörper (vertikale Anisotropie) kann anhand dieser Information berechnet werden."@de ,
-                                                                                                                    "This value object describes a variation in the dimension of a test piece referring to its transversal axis affecting its cross-sectional area that may potentially occur during a tensile test. The ratio of the true plastic strain in width and the true plastic strain in thickness in a test piece loaded in uniaxial tension (vertical anisotropy) may be calculated using this information."@en .
-
-
-###  http://material-digital.de/pmdao/tto/Chemical
-<http://material-digital.de/pmdao/tto/Chemical> rdf:type owl:Class ;
-                                                rdfs:subClassOf <http://material-digital.de/pmdao/tto/MaterialProperty> ;
-                                                <http://material-digital.de/pmdao/tto/definitionSource> "“Chemical.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/chemical. Accessed 13 Jan. 2023."@en ;
-                                                rdfs:label "Chemical"@en ,
-                                                           "Chemisch"@de ;
-                                                <http://www.w3.org/2004/02/skos/core#definition> "Chemical is relating to, used in, or produced by chemistry or the phenomena of chemistry Here specifically to the chemical properties of a material."@en ,
-                                                                                                 "Chemisch ist ein Begriff, der sich auf die Chemie oder die chemischen Phänomene bezieht, in der Chemie verwendet wird oder durch sie erzeugt wird. Hier geht es speziell um die chemischen Eigenschaften eines Materials."@de .
-
-
-###  http://material-digital.de/pmdao/tto/ChemicalComposition
-<http://material-digital.de/pmdao/tto/ChemicalComposition> rdf:type owl:Class ;
-                                                           owl:equivalentClass [ rdf:type owl:Restriction ;
-                                                                                 owl:onProperty [ owl:inverseOf <http://purl.org/dc/terms/isPartOf>
-                                                                                                ] ;
-                                                                                 owl:someValuesFrom <http://material-digital.de/pmdao/tto/ChemicalObject>
-                                                                               ] ;
-                                                           rdfs:subClassOf <http://material-digital.de/pmdao/tto/ValueObject> ;
-                                                           <http://material-digital.de/pmdao/tto/definitionSource> "http://chem.libretexts.org/Courses/College_of_Marin/CHEM_114%3A_Introductory_Chemistry/06%3A_Chemical_Composition" ;
-                                                           rdfs:label "Chemical Composition"@en ,
-                                                                      "Chemische Zusammensetzung"@de ;
-                                                           <http://www.w3.org/2004/02/skos/core#definition> "Chemical composition refers to the arrangement, type, and ratio of atoms in molecules of chemical substances. Chemical composition varies when chemicals are added or subtracted from a substance, when the ratio of substances changes, or when other chemical changes occur in chemicals."@en ;
-                                                           <http://www.w3.org/2004/02/skos/core#example> """ex:proc1 a pmd:Process .
-ex:proc1 pmd:hasChacteristic ex:vo1 .
-
-ex:vo1 a ValueObject .
-ex:vo1 hasResource ex:chemComp1 .
-ex:chemComp1 a pmd:ChemicalComposition .
-
-ex:vo2 dcterm:partOf ex:chemComp1 .
-ex:vo2 a pmd:ChemicalElement .
-ex:vo2 pmd:relatesToElement CHEBI:28984 .
-ex:vo2 pmd:relatesTo ex:vo3 .
-
-pmd:MassFraction rdf:subClassOf ValueObject .
-ex:vo3 a pmd:MassFraction .
-ex:vo3 qudt:upperBound \"0.3\" .
-ex:vo3 qudt:lowerBound \"0\" .
-ex:vo3 qudt:hasUnit qudt:PERCENT .
-
-ex:vo4 a pmd:MassFraction .
-ex:vo4 pmd:hasResource pmd:NotDetected .""" .
-
-
-###  http://material-digital.de/pmdao/tto/ChemicalObject
-<http://material-digital.de/pmdao/tto/ChemicalObject> rdf:type owl:Class ;
-                                                      owl:equivalentClass [ owl:intersectionOf ( <http://material-digital.de/pmdao/tto/ValueObject>
-                                                                                                 [ rdf:type owl:Restriction ;
-                                                                                                   owl:onProperty <http://material-digital.de/pmdao/tto/relatesTo> ;
-                                                                                                   owl:someValuesFrom <http://purl.obolibrary.org/obo/CHEBI_24431>
-                                                                                                 ]
-                                                                                               ) ;
-                                                                            rdf:type owl:Class
-                                                                          ] ;
-                                                      rdfs:subClassOf <http://material-digital.de/pmdao/tto/ValueObject> ;
-                                                      rdfs:label "Chemical Object"@en ,
-                                                                 "Chemisches Objekt"@de ;
-                                                      <http://www.w3.org/2004/02/skos/core#definition> "Value object that describes the quantity (e.g. mass fraction) of a specific chemical object."@en .
-
-
-###  http://material-digital.de/pmdao/tto/Circular
-<http://material-digital.de/pmdao/tto/Circular> rdf:type owl:Class ;
-                                                rdfs:subClassOf <http://material-digital.de/pmdao/tto/Shape> ;
-                                                <http://material-digital.de/pmdao/tto/definitionSource> "“Circular.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/circular. Accessed 13 Jan. 2023."@en ;
-                                                rdfs:label "Circular"@en ,
-                                                           "Kreisförmig"@de ;
-                                                <http://www.w3.org/2004/02/skos/core#definition> "Geformt wie ein Kreis."@de ,
-                                                                                                 "Having the form of a circle."@en .
-
-
-###  http://material-digital.de/pmdao/tto/ClampingPressure
-<http://material-digital.de/pmdao/tto/ClampingPressure> rdf:type owl:Class ;
-                                                        rdfs:subClassOf <http://material-digital.de/pmdao/tto/Stress> ;
-                                                        rdfs:label "Clamping Pressure"@en ,
-                                                                   "Klemmdruck"@de ;
-                                                        <http://www.w3.org/2004/02/skos/core#definition> "Diese Eigenschaft beschreibt als quantitativer Wert die Kraft pro Fläche (Druck), die beim Einbau einer Probe, eines Prüfkörpers oder eines Prüfstücks aufgebracht wird. Typischerweise ist das Aufbringen eines Klemmdrucks mit einer Art von Klemm- oder Spannzubehör (Grips) oder Ähnlichem verbunden."@de ,
-                                                                                                         "This property describes the force per area (pressure) that is used during the mounting process of a sample, specimen, or test piece as a quantitative value. Typically, this process involves some sort of grips or the like."@en .
-
-
-###  http://material-digital.de/pmdao/tto/ClassificationDocument
-<http://material-digital.de/pmdao/tto/ClassificationDocument> rdf:type owl:Class ;
-                                                              rdfs:subClassOf <http://material-digital.de/pmdao/tto/Document> ;
-                                                              rdfs:label "Classification Document"@en ,
-                                                                         "Klassifzierungsdokument"@de ;
-                                                              <http://www.w3.org/2004/02/skos/core#definition> "Diese Entität beschreibt ein Dokument, das dazu dient, den Arbeits- oder Anwendungsbereich eines Prozessknotens in Übereinstimmung mit genormten Abstufungen zu definieren."@de ,
-                                                                                                               "This entity describes a document used to define the working or application range of a process node in accordance with standardized graduations."@en .
-
-
-###  http://material-digital.de/pmdao/tto/CoatingDesignation
-<http://material-digital.de/pmdao/tto/CoatingDesignation> rdf:type owl:Class ;
-                                                          rdfs:subClassOf <http://material-digital.de/pmdao/tto/MaterialRelated> ;
-                                                          rdfs:label "Beschichtungsbezeichnung"@de ,
-                                                                     "Coating Designation"@en ;
-                                                          <http://www.w3.org/2004/02/skos/core#definition> "Diese Eigenschaft ist ein Name oder Bezeichner eines Materialtyps, welcher den obersten Teil eines Bauteils (Beschichtung) bedeckt."@de ,
-                                                                                                           "This property is a name or identifier of a material type which designates the most upper part of a component (coating)."@en .
-
-
-###  http://material-digital.de/pmdao/tto/CollectionInterfaceHint
-<http://material-digital.de/pmdao/tto/CollectionInterfaceHint> rdf:type owl:Class ;
-                                                               rdfs:subClassOf <http://material-digital.de/pmdao/tto/NodeInfo> ;
-                                                               rdfs:label "Collection Interface Hint"@en ,
-                                                                          "Datenschnittstellenhinweis"@de ;
-                                                               <http://www.w3.org/2004/02/skos/core#definition> "A label in support of identifying a network interface and/or address used by a process node to provide primary data stored in ontologies"@en .
-
-
-###  http://material-digital.de/pmdao/tto/CommissionTime
-<http://material-digital.de/pmdao/tto/CommissionTime> rdf:type owl:Class ;
-                                                      rdfs:subClassOf <http://material-digital.de/pmdao/tto/Time> ;
-                                                      rdfs:label "Commission Time"@en ,
-                                                                 "Kommissionszeit"@de ;
-                                                      <http://www.w3.org/2004/02/skos/core#definition> "Date and time an order or plan has been dispatched at."@en .
-
-
-###  http://material-digital.de/pmdao/tto/Component
-<http://material-digital.de/pmdao/tto/Component> rdf:type owl:Class ;
-                                                 rdfs:subClassOf <http://material-digital.de/pmdao/tto/Object> ;
-                                                 rdfs:label "Component"@en ,
-                                                            "Komponente"@de ;
-                                                 <http://www.w3.org/2004/02/skos/core#definition> "An object that serves a specific technical application. Constituent part of a compound of parts that builds a technical application"@en .
-
-
-###  http://material-digital.de/pmdao/tto/ConditioningProcess
-<http://material-digital.de/pmdao/tto/ConditioningProcess> rdf:type owl:Class ;
-                                                           rdfs:subClassOf <http://material-digital.de/pmdao/tto/Process> ;
-                                                           rdfs:label "Conditioning Process"@en ,
-                                                                      "Konditionierungsprozess"@de ;
-                                                           <http://www.w3.org/2004/02/skos/core#definition> "Diese Eigenschaft beschreibt den Prozess und die Maßnahmen, die ergriffen werden, um einen materiellen Gegenstand auf vordefinierte Umgebungsbedingungen einzustellen."@de ,
-                                                                                                            "This property describes the process of and the measures taken to set a tangible object to pre-defined environmental conditions."@en .
-
-
-###  http://material-digital.de/pmdao/tto/CovalentBond
-<http://material-digital.de/pmdao/tto/CovalentBond> rdf:type owl:Class ;
-                                                    rdfs:subClassOf <http://material-digital.de/pmdao/tto/BondingType> ;
-                                                    <http://material-digital.de/pmdao/tto/definitionSource> "\"Covalent bond.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/covalent%20bond. Accessed 13 Jan. 2023."@en ;
-                                                    rdfs:label "Covalent Bond"@en ,
-                                                               "Kovalente Bindung"@de ;
-                                                    <http://www.w3.org/2004/02/skos/core#definition> "Covalent bond is a chemical bond formed between atoms by the sharing of electrons."@en ,
-                                                                                                     "Eine kovalente Bindung ist eine chemische Verbindung zwischen Atomen, die durch die gemeinsame Nutzung von Elektronen entsteht."@de .
-
-
-###  http://material-digital.de/pmdao/tto/CreepStress
-<http://material-digital.de/pmdao/tto/CreepStress> rdf:type owl:Class ;
-                                                   rdfs:subClassOf <http://material-digital.de/pmdao/tto/Stress> ;
-                                                   rdfs:label "Creep Stress"@en ,
-                                                              "Kriechspannung"@de ;
-                                                   <http://www.w3.org/2004/02/skos/core#definition> "Is the strain occuring with time, when a constant force is applied to a physical body."@en .
-
-
-###  http://material-digital.de/pmdao/tto/CrossSectionArea
-<http://material-digital.de/pmdao/tto/CrossSectionArea> rdf:type owl:Class ;
-                                                        rdfs:subClassOf <http://material-digital.de/pmdao/tto/Area> ;
-                                                        <http://material-digital.de/pmdao/tto/definitionSource> "http://www.merriam-webster.com/dictionary/cross%20section"@en ;
-                                                        rdfs:label "Cross Section Area"@en ,
-                                                                   "Querschnittsfläche"@de ;
-                                                        <http://www.w3.org/2004/02/skos/core#definition> "Diese Eigenschaft beschreibt die Fläche eines Schnittes oder eines rechtwinklig geschnittenen oder gebrochenen Stücks eines Objektes in Bezug auf eine Achse."@de ,
-                                                                                                         "This property describes the area of a cutting or piece of an object cut off or broken at right angles or related to an axis."@en .
-
-
-###  http://material-digital.de/pmdao/tto/CrossSectionDetermination
-<http://material-digital.de/pmdao/tto/CrossSectionDetermination> rdf:type owl:Class ;
-                                                                 rdfs:subClassOf <http://material-digital.de/pmdao/tto/Method> ;
-                                                                 <http://material-digital.de/pmdao/tto/definitionSource> "“Cross section.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/cross%20section. Accessed 24 Nov. 2022."@en ;
-                                                                 rdfs:label "Cross Section Determination"@en ,
-                                                                            "Querschnittsermittlung"@de ;
-                                                                 <http://www.w3.org/2004/02/skos/core#definition> """Cross section is a cutting or piece of something cut off at right angles to an axis
-also : a representation of such a cutting."""@en ;
-                                                                 <http://www.w3.org/2004/02/skos/core#example> "Using the density of the test piece."@en .
-
-
-###  http://material-digital.de/pmdao/tto/CrossheadSeparation
-<http://material-digital.de/pmdao/tto/CrossheadSeparation> rdf:type owl:Class ;
-                                                           rdfs:subClassOf <http://material-digital.de/pmdao/tto/ValueObject> ;
-                                                           <http://material-digital.de/pmdao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en ;
-                                                           rdfs:label "Crosshead Separation"@en ,
-                                                                      "Querhaupttrennung"@de ;
-                                                           <http://www.w3.org/2004/02/skos/core#definition> "Diese Eigenschaft beschreibt die Verschiebung der Traverse einer Prüfmaschine."@de ,
-                                                                                                            """Dimensional analysis: L
-Unit (e.g. SI): mm"""@en ,
-                                                                                                            "This property describes the displacement of the crossheads of a testing machine."@en .
-
-
-###  http://material-digital.de/pmdao/tto/CrossheadSeparationRate
-<http://material-digital.de/pmdao/tto/CrossheadSeparationRate> rdf:type owl:Class ;
-                                                               rdfs:subClassOf <http://material-digital.de/pmdao/tto/TestingRate> ;
-                                                               <http://material-digital.de/pmdao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en ;
-                                                               rdfs:label "Crosshead Separation Rate"@en ,
-                                                                          "Traversengeschwindigkeit"@de ;
-                                                               <http://www.w3.org/2004/02/skos/core#definition> "Symbol: v_c"@en ,
-                                                                                                                "Traversenweg je Zeiteinheit"@de ,
-                                                                                                                "displacement of the crossheads per time"@en .
-
-
-###  http://material-digital.de/pmdao/tto/CrystallineStructure
-<http://material-digital.de/pmdao/tto/CrystallineStructure> rdf:type owl:Class ;
-                                                            rdfs:subClassOf <http://material-digital.de/pmdao/tto/MaterialStructure> ;
-                                                            <http://material-digital.de/pmdao/tto/definitionSource> "“Crystal structure.” Wikipedia The Free Encyclopedia, http://en.wikipedia.org/wiki/Crystal_structure. Accessed 13 Jan. 2023."@en ;
-                                                            rdfs:label "Crystalline Structure"@en ,
-                                                                       "Kristalline Struktur"@de ;
-                                                            <http://www.w3.org/2004/02/skos/core#definition> "In crystallography, crystal structure is a description of the ordered arrangement of atoms, ions or molecules in a crystalline material. Ordered structures occur from the intrinsic nature of the constituent particles to form symmetric patterns that repeat along the principal directions of three-dimensional space in matter."@en ,
-                                                                                                             "In der Kristallographie ist die Kristallstruktur eine Beschreibung der geordneten Anordnung von Atomen, Ionen oder Molekülen in einem kristallinen Material. Geordnete Strukturen ergeben sich aus der intrinsischen Natur der konstituierenden Teilchen, die symmetrische Muster bilden, die sich entlang der Hauptrichtungen des dreidimensionalen Raums in der Materie wiederholen."@de .
-
-
-###  http://material-digital.de/pmdao/tto/DataAcquisitionRate
-<http://material-digital.de/pmdao/tto/DataAcquisitionRate> rdf:type owl:Class ;
-                                                           rdfs:subClassOf <http://material-digital.de/pmdao/tto/ValueObject> ;
-                                                           rdfs:label "Data Acquisition Rate"@en ,
-                                                                      "Datenerfassungsrate"@de ;
-                                                           <http://www.w3.org/2004/02/skos/core#definition> "Diese Eigenschaft bezeichnet die Anzahl der Messungen / Abfragen pro Zeiteinheit bei einer betrachteten Messung einer Messgröße (Abtast-/Abfragerate bei der Datenerfassung)."@de ,
-                                                                                                            "This property denotes the number of measurements / queries per time period for a considered measurement of a measurement parameter (sampling / query rate during data acquisition)."@en .
-
-
-###  http://material-digital.de/pmdao/tto/DataCiteMetadata
-<http://material-digital.de/pmdao/tto/DataCiteMetadata> rdf:type owl:Class ;
-                                                        rdfs:subClassOf <http://material-digital.de/pmdao/tto/ValueObject> ;
-                                                        rdfs:label "Data Cite Metadaten"@de ,
-                                                                   "DataCite Metadata"@en ;
-                                                        <http://www.w3.org/2004/02/skos/core#definition> "This value object refers to metadata which can be provided as DataCite element."@en ;
-                                                        <http://www.w3.org/2004/02/skos/core#example> """For example, to refer to a ISBN number, following triples might be created:
-
-    :p1 a pmd:Process .
-    :p1 pmd:hasCharacteristic :doc_vo1 .
-    :doc_vo1 a pmd:Document .
-    :doc_vo1 pmd:hasCharacteristic :isbn_vo1 .
-    :doc_vo1 pmd:hasResource \"http://example.org/book.pdf\" .
-    :isbn_vo1 a pmd:DataCiteMetadata .
-    :isbn_vo1 pmd:relatesTo <http://purl.org/spar/datacite/isbn> .
-    :isbn_vo1 pmd:hasValue \"9780262012423\". 
-
-\"a document related to process :p1 has a ISBN number 9780262012423\""""@en .
-
-
-###  http://material-digital.de/pmdao/tto/DataScope
-<http://material-digital.de/pmdao/tto/DataScope> rdf:type owl:Class ;
-                                                 rdfs:subClassOf <http://www.w3.org/ns/prov#Entity> ;
-                                                 rdfs:label "Data Scope"@en ,
-                                                            "Datenkategorie"@de ;
-                                                 <http://www.w3.org/2004/02/skos/core#definition> "This property is used to categorize data with respect to their intended usage in accordance with a regarded object or process."@en .
-
-
-###  http://material-digital.de/pmdao/tto/Date
-<http://material-digital.de/pmdao/tto/Date> rdf:type owl:Class ;
-                                            rdfs:subClassOf <http://material-digital.de/pmdao/tto/Time> ;
-                                            rdfs:label "Date"@en ,
-                                                       "Datum"@de ;
-                                            <http://www.w3.org/2004/02/skos/core#definition> "A statement of the day of execution or making. Based on an the gregorian calender system."@en ,
-                                                                                             "Eine Erklärung über den Tag der Ausführung oder Herstellung. Basierend auf dem gregorianischen Kalendersystem."@de .
-
-
-###  http://material-digital.de/pmdao/tto/DemountingProcess
-<http://material-digital.de/pmdao/tto/DemountingProcess> rdf:type owl:Class ;
-                                                         rdfs:subClassOf <http://material-digital.de/pmdao/tto/AssemblingProcess> ;
-                                                         rdfs:label "Demontageprozess"@de ,
-                                                                    "Demounting Process"@en ;
-                                                         <http://www.w3.org/2004/02/skos/core#definition> "This property is used to describe the process of removing or disassembling a test piece or specimen from a test machine. This may include the usage of other process nodes (e.g. grips)."@en .
-
-
-###  http://material-digital.de/pmdao/tto/Department
-<http://material-digital.de/pmdao/tto/Department> rdf:type owl:Class ;
-                                                  rdfs:subClassOf <http://www.w3.org/ns/prov#Organization> ;
-                                                  rdfs:label "Abteilung"@de ,
-                                                             "Department"@en ;
-                                                  <http://www.w3.org/2004/02/skos/core#definition> "A sub section of an organization [FIXME]"@en .
-
-
-###  http://material-digital.de/pmdao/tto/Description
-<http://material-digital.de/pmdao/tto/Description> rdf:type owl:Class ;
-                                                   rdfs:subClassOf <http://material-digital.de/pmdao/tto/ValueObject> ;
-                                                   rdfs:label "Beschreibung"@de ,
-                                                              "Description"@en ;
-                                                   <http://www.w3.org/2004/02/skos/core#definition> "A descriptive text qualifying the nature of a thing (e.g. agent, activity, entity, object, ...)." ,
-                                                                                                    "Ein beschreibender Text, der die Natur / Beschaffenheit / Informationen zu einer Entität qualifiziert (z.B. Aktivitäten, Entitäten, Objekten, ...)."@de .
-
-
-###  http://material-digital.de/pmdao/tto/Diameter
-<http://material-digital.de/pmdao/tto/Diameter> rdf:type owl:Class ;
-                                                rdfs:subClassOf <http://material-digital.de/pmdao/tto/ValueObject> ;
-                                                <http://material-digital.de/pmdao/tto/definitionSource> "“Diameter.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/diameter. Accessed 5 Dec. 2022."@en ;
-                                                rdfs:label "Diameter"@en ,
-                                                           "Durchmesser"@de ;
-                                                <http://www.w3.org/2004/02/skos/core#definition> "The length of a straight line through the center of an object or space."@en ;
-                                                <http://www.w3.org/ns/prov#constraints> "TesileTest" .
-
-
-###  http://material-digital.de/pmdao/tto/DiameterAfterFracture
-<http://material-digital.de/pmdao/tto/DiameterAfterFracture> rdf:type owl:Class ;
-                                                             rdfs:subClassOf <http://material-digital.de/pmdao/tto/Diameter> ;
-                                                             rdfs:label "Diameter After Fracture"@en ,
-                                                                        "End-Probendurchmesser"@de ;
-                                                             <http://www.w3.org/2004/02/skos/core#definition> "Die Länge einer geraden Linie durch den Mittelpunkt eines Objekts (Prüfstücks), gemessen nach einem Bruch, der während einer Prüfung aufgetreten ist."@de ,
-                                                                                                              "The length of a straight line through the center of an object (test piece) as measured after a fracture occured during a test."@en .
-
-
-###  http://material-digital.de/pmdao/tto/DigitalMaterialIdentifier
-<http://material-digital.de/pmdao/tto/DigitalMaterialIdentifier> rdf:type owl:Class ;
-                                                                 owl:equivalentClass [ owl:intersectionOf ( <http://material-digital.de/pmdao/tto/Identifier>
-                                                                                                            [ rdf:type owl:Restriction ;
-                                                                                                              owl:onProperty <http://material-digital.de/pmdao/tto/hasResource> ;
-                                                                                                              owl:someValuesFrom <http://w3id.org/DMI/DigitalMaterialIdentifier>
-                                                                                                            ]
-                                                                                                          ) ;
-                                                                                       rdf:type owl:Class
-                                                                                     ] ;
-                                                                 rdfs:subClassOf <http://material-digital.de/pmdao/tto/Identifier> ;
-                                                                 rdfs:label "Digital Material Identifier"@en ;
-                                                                 <http://www.w3.org/2004/02/skos/core#definition> """The DigitalMaterialIdentifier value object refers to a dmi:DigitalMaterialIdentifier.
-
-A dmi:DigitalMaterialIdentifier is a resource identifier (IRI) that represents the specification of a material (in the sense of a material class) described in a specification document. The specification document can be, e.g., a standard, a datasheet, or any other citable document. Typically, a specification document requires some qualities that a material (in the sense of a portion of matter) has to comply with. Typical requirements include chemical compositions or physical properties."""@en .
-
-
-###  http://material-digital.de/pmdao/tto/DimensionMeasuringDevice
-<http://material-digital.de/pmdao/tto/DimensionMeasuringDevice> rdf:type owl:Class ;
-                                                                rdfs:subClassOf <http://material-digital.de/pmdao/tto/MeasuringDevice> ;
-                                                                rdfs:label "Dimension Measuring Device"@en ,
-                                                                           "Dimensionsmesswerkzeug"@de ;
-                                                                <http://www.w3.org/2004/02/skos/core#definition> "Diese Entität beschreibt allgemein jedes Werkzeug, das für die Messung der Abmessungen eines greifbaren Objekts verwendet wird, z. B. eines Messschiebers."@de ,
-                                                                                                                 "This entity generically describes any tool that is used for the measurement of the dimensions of a tangible object, e.g., a caliper."@en .
-
-
-###  http://material-digital.de/pmdao/tto/Distance
-<http://material-digital.de/pmdao/tto/Distance> rdf:type owl:Class ;
-                                                rdfs:subClassOf <http://material-digital.de/pmdao/tto/ValueObject> ;
-                                                <http://material-digital.de/pmdao/tto/definitionSource> "“Distance.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/distance. Accessed 5 Dec. 2022."@en ;
-                                                rdfs:label "Abstand"@de ,
-                                                           "Distance"@en ;
-                                                <http://www.w3.org/2004/02/skos/core#definition> "Spatial remoteness."@en .
-
-
-###  http://material-digital.de/pmdao/tto/Document
-<http://material-digital.de/pmdao/tto/Document> rdf:type owl:Class ;
-                                                rdfs:subClassOf <http://material-digital.de/pmdao/tto/ValueObject> ;
-                                                <http://material-digital.de/pmdao/tto/definitionSource> "“Document.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/document. Accessed 16 Jan. 2023."@en ;
-                                                rdfs:label "Document"@en ,
-                                                           "Dokument"@de ;
-                                                <http://www.w3.org/2004/02/skos/core#definition> "An original or official paper relied on as the basis, proof, or support of something"@en ,
-                                                                                                 "Ein Original oder offizielles Papier, auf das man sich als Grundlage, Beweis oder Unterstützung von etwas stützt."@de .
-
-
-###  http://material-digital.de/pmdao/tto/Duration
-<http://material-digital.de/pmdao/tto/Duration> rdf:type owl:Class ;
-                                                rdfs:subClassOf <http://material-digital.de/pmdao/tto/Time> ;
-                                                rdfs:label "Dauer"@de ,
-                                                           "Duration"@en ;
-                                                <http://www.w3.org/2004/02/skos/core#definition> "A period of time with its own timescale and an epoch anchored in another timescale. A duration can be expressed via a single value as the first value of the period of time is always zero."@en ,
-                                                                                                 "Eine Zeitspanne mit einer eigenen Zeitskala und einer in einer anderen Zeitskala verankerten Epoche. Eine Dauer kann mit einem einzigen Wert ausgedrückt werden, da der erste Wert der Zeitspanne immer Null ist."@de .
-
-
-###  http://material-digital.de/pmdao/tto/Electrical
-<http://material-digital.de/pmdao/tto/Electrical> rdf:type owl:Class ;
-                                                  rdfs:subClassOf <http://material-digital.de/pmdao/tto/MaterialProperty> ;
-                                                  <http://material-digital.de/pmdao/tto/definitionSource> "“Electric.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/electric. Accessed 13 Jan. 2023."@en ;
-                                                  rdfs:label "Electrical"@en ,
-                                                             "Elektrisch"@de ;
-                                                  <http://www.w3.org/2004/02/skos/core#definition> "Electrical is relating to electricity or something that is powered by electricity. Here specifically to the electrical properties of a material."@en ,
-                                                                                                   "Elektrisch bezieht sich auf Elektrizität oder etwas, das mit Elektrizität betrieben wird. Hier speziell auf die elektrischen Eigenschaften eines Materials."@de .
-
-
-###  http://material-digital.de/pmdao/tto/Elliptical
-<http://material-digital.de/pmdao/tto/Elliptical> rdf:type owl:Class ;
-                                                  rdfs:subClassOf <http://material-digital.de/pmdao/tto/Shape> ;
-                                                  <http://material-digital.de/pmdao/tto/definitionSource> "“Elliptical.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/elliptical. Accessed 13 Jan. 2023."@en ;
-                                                  rdfs:label "Elliptical"@en ,
-                                                             "Elliptisch"@de ;
-                                                  <http://www.w3.org/2004/02/skos/core#definition> "Geformt wie eine Ellipse."@de ,
-                                                                                                   "Shaped like an ellipse."@en .
-
-
-###  http://material-digital.de/pmdao/tto/Elongation
-<http://material-digital.de/pmdao/tto/Elongation> rdf:type owl:Class ;
-                                                  owl:equivalentClass [ rdf:type owl:Restriction ;
-                                                                        owl:onProperty <http://material-digital.de/pmdao/tto/relatesTo> ;
-                                                                        owl:someValuesFrom <http://material-digital.de/pmdao/tto/OriginalGaugeLength>
-                                                                      ] ;
-                                                  rdfs:subClassOf <http://material-digital.de/pmdao/tto/ValueObject> ;
-                                                  <http://material-digital.de/pmdao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en ;
-                                                  rdfs:label "Elongation"@en ,
-                                                             "Verlängerung"@de ;
-                                                  <http://www.w3.org/2004/02/skos/core#definition> "Zunahme der Anfangsmesslänge zu einem beliebigen Zeitpunkt während des Versuchs"@de ,
-                                                                                                   "increase in the original gauge length at any moment during the test"@en .
-
-
-###  http://material-digital.de/pmdao/tto/EndTime
-<http://material-digital.de/pmdao/tto/EndTime> rdf:type owl:Class ;
-                                               rdfs:subClassOf <http://material-digital.de/pmdao/tto/Time> ;
-                                               rdfs:label "End Time"@en ,
-                                                          "Endzeit"@de ;
-                                               <http://www.w3.org/2004/02/skos/core#definition> "The date and time when the plan/recipe is supposed to have been finished"@en .
-
-
-###  http://material-digital.de/pmdao/tto/EngineeredMaterial
-<http://material-digital.de/pmdao/tto/EngineeredMaterial> rdf:type owl:Class ;
-                                                          rdfs:subClassOf <http://material-digital.de/pmdao/tto/Object> ;
-                                                          rdfs:label "Engineered Material"@en ;
-                                                          <http://www.w3.org/2004/02/skos/core#definition> "A material that is synthesized within a manufacturing process."@en ,
-                                                                                                           "Ein Material, das im Rahmen eines Herstellungsprozesses synthetisiert wird."@de .
-
-
-###  http://material-digital.de/pmdao/tto/EngineeringStrain
-<http://material-digital.de/pmdao/tto/EngineeringStrain> rdf:type owl:Class ;
-                                                         owl:equivalentClass <http://material-digital.de/pmdao/tto/PercentageExtension> ;
-                                                         rdfs:subClassOf <http://material-digital.de/pmdao/tto/ValueObject> ;
-                                                         <http://material-digital.de/pmdao/tto/definitionSource> "http://www.corrosionpedia.com/definition/6405/engineering-strain"@en ;
-                                                         rdfs:label "Engineering Strain"@en ,
-                                                                    "technische Dehnung"@de ;
-                                                         <http://www.w3.org/2004/02/skos/core#definition> "Diese Eigenschaft bezieht sich auf den Grad der Verformung, den ein Material in Richtung der einwirkenden Kräfte im Verhältnis zu seiner ursprünglichen Länge aushält. Die technische Dehnung ist direkt proportional zum Betrag der Dehnung eines Objekts."@de ,
-                                                                                                          "This property refers to the degree of deformation that a material withstands in the direction of applied forces in relation to its original length. Engineering strain is directly proportional to the amount of elongation experienced by an object."@en .
-
-
-###  http://material-digital.de/pmdao/tto/EnvironmentalTemperature
-<http://material-digital.de/pmdao/tto/EnvironmentalTemperature> rdf:type owl:Class ;
-                                                                rdfs:subClassOf <http://material-digital.de/pmdao/tto/Temperature> ;
-                                                                rdfs:label "Environmental Temperature"@en ,
-                                                                           "Umgebungstemperatur"@de ;
-                                                                <http://www.w3.org/2004/02/skos/core#definition> "Diese Eigenschaft beschreibt die beobachtete Temperatur in der Umgebung eines betrachteten materiellen Objekts. Dazu können die Raumtemperatur und die in Prüfkammern gemessenen Temperaturen gehören."@de ,
-                                                                                                                 "This property describes the observed temperature surrounding a tangible object considered. This may include room temperature and temperatures measured in test chambers."@en .
-
-
-###  http://material-digital.de/pmdao/tto/ErrorReportDocument
-<http://material-digital.de/pmdao/tto/ErrorReportDocument> rdf:type owl:Class ;
-                                                           rdfs:subClassOf <http://material-digital.de/pmdao/tto/Document> ;
-                                                           rdfs:label "Error Report Document"@en ,
-                                                                      "Fehlerberichtdokument"@de ;
-                                                           <http://www.w3.org/2004/02/skos/core#definition> "Diese Entität beschreibt ein Dokument, das Informationen über Fehler bereitstellt, die während der Anwendung eines Prozessknotens aufgetreten sind, wie z. B. eine Überschreitung des Arbeitsbereichs eines Messgeräts."@de ,
-                                                                                                            "This entity describes a document used to provide information on errors that occurred during the application of a process node, such as, e.g., an overshooting exceeding the working range of a measurement device."@en .
-
-
-###  http://material-digital.de/pmdao/tto/EstimatedStrainRateOverTheParallelLength
-<http://material-digital.de/pmdao/tto/EstimatedStrainRateOverTheParallelLength> rdf:type owl:Class ;
-                                                                                rdfs:subClassOf <http://material-digital.de/pmdao/tto/TestingRate> ;
-                                                                                <http://material-digital.de/pmdao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en ;
-                                                                                rdfs:label "Abgeschätzte Dehngeschwindigkeit Über Die Parallele Länge"@de ,
-                                                                                           "Estimated Strain Rate Over The Parallel Length"@en ;
-                                                                                <http://www.w3.org/2004/02/skos/core#definition> "Symbol: e^._L_c"@en ,
-                                                                                                                                 "Zunahme der Dehnung über die parallele Länge der Probe je Zeiteinheit, basierend auf der Traversengeschwindigkeit und der parallelen Länge der Probe"@de ,
-                                                                                                                                 "value of the increase of strain over the parallel length of the test piece per time based on the crosshead separation rate and the parallel length of the test piece"@en .
-
-
-###  http://material-digital.de/pmdao/tto/Extension
-<http://material-digital.de/pmdao/tto/Extension> rdf:type owl:Class ;
-                                                 owl:equivalentClass [ rdf:type owl:Restriction ;
-                                                                       owl:onProperty <http://material-digital.de/pmdao/tto/relatesTo> ;
-                                                                       owl:someValuesFrom <http://material-digital.de/pmdao/tto/ExtensometerGaugeLength>
-                                                                     ] ;
-                                                 rdfs:subClassOf <http://material-digital.de/pmdao/tto/ValueObject> ;
-                                                 <http://material-digital.de/pmdao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en ;
-                                                 rdfs:label "Extension"@en ,
-                                                            "Verlängerung (der Extensometer-Messlänge)"@de ;
-                                                 <http://www.w3.org/2004/02/skos/core#definition> """Dimensional analysis: L
-Unit (e.g. SI): mm"""@en ,
-                                                                                                  "Increase in the extensometer gauge length at any moment during the test"@en ,
-                                                                                                  """Note: The extension might be measured using different channels (e.g. when using one or two extensometer channels); usually, the mean average value of involved channels is given as extension value, if applicable.
-
-Note: Optical extensometry may require a specific data storage method."""@en ,
-                                                                                                  "Zunahme der Extensometer-Messlänge zu einem beliebigen Zeitpunkt des Versuchs"@de .
-
-
-###  http://material-digital.de/pmdao/tto/Extensometer
-<http://material-digital.de/pmdao/tto/Extensometer> rdf:type owl:Class ;
-                                                    rdfs:subClassOf <http://material-digital.de/pmdao/tto/MeasuringDevice> ;
-                                                    <http://material-digital.de/pmdao/tto/definitionSource> "“Extensometer.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/extensometer. Accessed 5 Dec. 2022."@en ;
-                                                    rdfs:label "Extensometer"@en ;
-                                                    <http://www.w3.org/2004/02/skos/core#definition> "An instrument for measuring minute deformations of test specimens caused by tension, compression, bending, or twisting."@en .
-
-
-###  http://material-digital.de/pmdao/tto/ExtensometerGaugeLength
-<http://material-digital.de/pmdao/tto/ExtensometerGaugeLength> rdf:type owl:Class ;
-                                                               rdfs:subClassOf <http://material-digital.de/pmdao/tto/GaugeLength> ;
-                                                               <http://material-digital.de/pmdao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en ;
-                                                               rdfs:label "Extensometer Gauge Length"@en ,
-                                                                          "Extensometer-Messlänge"@de ;
-                                                               <http://www.w3.org/2004/02/skos/core#definition> """Anfangsmesslänge des Dehnungsaufnehmers (Extensometer), die zum Messen der Verlängerung benutzt wird
-
-Anmerkung: Für die Bestimmung mehrerer Eigenschaften, die (teilweise oder vollständig) von der Verlängerung abhängig sind, z. B. R_p, A_e oder A_g, ist die Verwendung eines Extensometers zwingend erforderlich."""@de ,
-                                                                                                                "Symbol: L_e"@en ,
-                                                                                                                """initial gauge length of the extensometer used for measurement of extension
-
-Note: For the determination of several properties which are based (partly or complete) on extension, e. g. R_p, A_e or A_g, the use of an extensometer is mandatory."""@en .
-
-
-###  http://material-digital.de/pmdao/tto/Filter
-<http://material-digital.de/pmdao/tto/Filter> rdf:type owl:Class ;
-                                              rdfs:subClassOf <http://material-digital.de/pmdao/tto/Algorithm> ;
-                                              <http://material-digital.de/pmdao/tto/definitionSource> "http://en.wikipedia.org/wiki/Filter_%28software%29"@en ;
-                                              rdfs:label "Filter"@de ,
-                                                         "Filter"@en ;
-                                              <http://www.w3.org/2004/02/skos/core#definition> "A filter is a computer program or subroutine to process a stream, producing another stream. While a single filter can be used individually, they are frequently strung together to form a pipeline."@en ;
-                                              <http://www.w3.org/2004/02/skos/core#example> "Smoothing algorithm"@en .
-
-
-###  http://material-digital.de/pmdao/tto/FinalGaugeLengthAfterFracture
-<http://material-digital.de/pmdao/tto/FinalGaugeLengthAfterFracture> rdf:type owl:Class ;
-                                                                     rdfs:subClassOf <http://material-digital.de/pmdao/tto/GaugeLength> ;
-                                                                     <http://material-digital.de/pmdao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en ;
-                                                                     rdfs:label "Final Gauge Length After Fracture"@en ,
-                                                                                "Messlänge nach dem Bruch"@de ,
-                                                                                "Symbol: L_u"@en ;
-                                                                     <http://www.w3.org/2004/02/skos/core#definition> "Länge zwischen den Marken zur Kennzeichnung der Messlänge auf der Probe, die nach dem Bruch bei Raumtemperatur gemessen wird, nachdem die beiden Probenbruchstücke sorgfältig so zusammengefügt wurden, dass ihre Achsen in einer Geraden liegen"@de ,
-                                                                                                                      "length between gauge length marks on the test piece measured after rupture, at room temperature, the two pieces having been carefully fitted back together so that their axes lie in a straight line"@en .
-
-
-###  http://material-digital.de/pmdao/tto/FinalProcess
-<http://material-digital.de/pmdao/tto/FinalProcess> rdf:type owl:Class ;
-                                                    owl:equivalentClass [ owl:intersectionOf ( <http://material-digital.de/pmdao/tto/Process>
-                                                                                               [ rdf:type owl:Restriction ;
-                                                                                                 owl:onProperty <http://material-digital.de/pmdao/tto/hasNextProcess> ;
-                                                                                                 owl:maxQualifiedCardinality "0"^^xsd:nonNegativeInteger ;
-                                                                                                 owl:onClass <http://material-digital.de/pmdao/tto/Process>
-                                                                                               ]
-                                                                                             ) ;
-                                                                          rdf:type owl:Class
-                                                                        ] ;
-                                                    rdfs:subClassOf <http://material-digital.de/pmdao/tto/Process> ;
-                                                    rdfs:label "Final Process"@en ,
-                                                               "Finaler Prozess"@de ;
-                                                    <http://www.w3.org/2004/02/skos/core#definition> "Diese Klasse wird verwendet, um den letzten von einem Prozessknoten durchgeführten Prozess in einer Reihe von Prozessen anzugeben, die von demselben Prozessknoten durchgeführt werden."@de ,
-                                                                                                     "This class is used to indicate the last process conducted by a process node in a series of processes conducted by the same process node."@en .
-
-
-###  http://material-digital.de/pmdao/tto/Force
-<http://material-digital.de/pmdao/tto/Force> rdf:type owl:Class ;
-                                             rdfs:subClassOf <http://material-digital.de/pmdao/tto/ValueObject> ;
-                                             <http://material-digital.de/pmdao/tto/definitionSource> "“Force.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/force. Accessed 5 Dec. 2022."@en ;
-                                             rdfs:label "Force"@en ,
-                                                        "Kraft"@de ;
-                                             <http://www.w3.org/2004/02/skos/core#definition> "Strength or energy exerted or brought to bear : cause of motion or change : active power."@en .
-
-
-###  http://material-digital.de/pmdao/tto/GaugeLength
-<http://material-digital.de/pmdao/tto/GaugeLength> rdf:type owl:Class ;
-                                                   rdfs:subClassOf <http://material-digital.de/pmdao/tto/Length> ;
-                                                   <http://material-digital.de/pmdao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en ;
-                                                   rdfs:label "Gauge Length"@en ,
-                                                              "Messlänge"@de ;
-                                                   <http://www.w3.org/2004/02/skos/core#definition> "Länge des parallelen Teils der Probe, an dem zu einem beliebigen Zeitpunkt während des Versuchs die Verlängerung gemessen wird"@de ,
-                                                                                                    "Symbol: L"@en ,
-                                                                                                    "length of the parallel portion of the test piece on which elongation is measured at any moment during the test"@en .
-
-
-###  http://material-digital.de/pmdao/tto/GeometryShape
-<http://material-digital.de/pmdao/tto/GeometryShape> rdf:type owl:Class ;
-                                                     rdfs:subClassOf <http://material-digital.de/pmdao/tto/TestPieceInfo> ;
-                                                     <http://material-digital.de/pmdao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en ;
-                                                     rdfs:label "Geometrische Form"@de ,
-                                                                "Geometry Shape"@en ;
-                                                     <http://www.w3.org/2004/02/skos/core#definition> "Diese Eigenschaft beschreibt die geometrischen Abmessungen und das Erscheinungsbild (Form und Abmaße) einer Probe, eines Prüfkörpers oder eines Prüfstücks, wie sie üblicherweise durch eine entsprechende Norm definiert sind. Dementsprechend ist der angegebene Formwert in Übereinstimmung mit der definierenden Norm anzugeben, z. B. \"Zugprüfstück Form 1 gemäß Anhang B\"."@de ,
-                                                                                                      "This property describes the geometric dimensions and appearance (shape and dimensions) of a sample, specimen, or test piece as usually defined by a corresponding standard. Accordingly, the shape value given is in accordance with the defining standard, e.g., ‘tensile test piece shape 1 in accordance with annex B’."@en .
-
-
-###  http://material-digital.de/pmdao/tto/Grips
-<http://material-digital.de/pmdao/tto/Grips> rdf:type owl:Class ;
-                                             rdfs:subClassOf <http://material-digital.de/pmdao/tto/ProcessingNode> ;
-                                             <http://material-digital.de/pmdao/tto/definitionSource> "http://www.merriam-webster.com/dictionary/grips"@en ;
-                                             rdfs:label "Grips"@en ,
-                                                        "Halterungsklemmen"@de ;
-                                             <http://www.w3.org/2004/02/skos/core#definition> "Diese Entität beschreibt ein Bauelement / Teil, mit dem etwas, normalerweise ein materielles Objekt, fest gegriffen oder eingespannt wird. Typischerweise sind Halterungen, Klemm- bzw. Spannsysteme Teil eines Befestigungssystems (Prozessknoten), das sich auf ein Prüfsystem bezieht."@de ,
-                                                                                              "This entity describes a part by which something, usually a tangible object, is grasped. Typically, grips are part of a mounting system (process node) referring to a testing system."@en .
-
-
-###  http://material-digital.de/pmdao/tto/GripsAlignment
-<http://material-digital.de/pmdao/tto/GripsAlignment> rdf:type owl:Class ;
-                                                      rdfs:subClassOf <http://material-digital.de/pmdao/tto/QualifyingNodeAnnotation> ;
-                                                      rdfs:label "Ausrichtung Der Halterungen"@de ,
-                                                                 "Grips Alignment"@en ;
-                                                      <http://www.w3.org/2004/02/skos/core#definition> "Diese Eigenschaft beschreibt den Prozess der Ausrichtung von Halterungen, die zum Fest-/Einspannen eines materiellen Objekts, wie z. B. einer Probe, eines Prüfkörpers oder eines Prüfstücks, verwendet werden. Dieser Vorgang ist in der Regel Teil des Montageprozesses während der Prüfung, falls ein solcher durchgeführt wird."@de ,
-                                                                                                       "This property describes the process of forming in line of the grips used to grasp a tangible object, such as a sample, specimen, or test piece. This process is typically part of the mounting process during testing, if applicable."@en .
-
-
-###  http://material-digital.de/pmdao/tto/HeatTreatmentProcess
-<http://material-digital.de/pmdao/tto/HeatTreatmentProcess> rdf:type owl:Class ;
-                                                            rdfs:subClassOf <http://material-digital.de/pmdao/tto/ConditioningProcess> ;
-                                                            <http://material-digital.de/pmdao/tto/definitionSource> "“Heat-treat.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/heat-treat. Accessed 24 Nov. 2022."@en ;
-                                                            rdfs:label "Heat Treatment Process"@en ,
-                                                                       "Wärmebehandlung"@de ;
-                                                            <http://www.w3.org/2004/02/skos/core#definition> "The process of heat treatment means a defined temperature change and a holding to achieve a change in the microstructure, residual stresses, defect distribution or local chemical composition of a material."@en ,
-                                                                                                             "To treat (a material, such as metal) by heating and cooling in a way that will produce desired properties."@en .
-
-
-###  http://material-digital.de/pmdao/tto/HydrogenBond
-<http://material-digital.de/pmdao/tto/HydrogenBond> rdf:type owl:Class ;
-                                                    rdfs:subClassOf <http://material-digital.de/pmdao/tto/BondingType> ;
-                                                    <http://material-digital.de/pmdao/tto/definitionSource> "\"Hydrogen bond.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/hydrogen%20bond. Accessed 13 Jan. 2023."@en ;
-                                                    rdfs:label "Hydrogen Bond"@en ,
-                                                               "Wasserstoffbindung"@de ;
-                                                    <http://www.w3.org/2004/02/skos/core#definition> "Eine Wasserstoffbindung ist eine elektrostatische Anziehung zwischen einem Wasserstoffatom in einem polaren Molekül (z. B. Wasser) und einem kleinen elektronegativen Atom (z. B. Sauerstoff, Stickstoff oder Fluor) in einem anderen Molekül der gleichen oder einer anderen polaren Substanz."@de ,
-                                                                                                     "Hydrogen bond is an electrostatic attraction between a hydrogen atom in one polar molecule (as of water) and a small electronegative atom (as of oxygen, nitrogen, or fluorine) in usually another molecule of the same or a different polar substance."@en .
-
-
-###  http://material-digital.de/pmdao/tto/ISO6892-1TensileTest
-<http://material-digital.de/pmdao/tto/ISO6892-1TensileTest> rdf:type owl:Class ;
-                                                            owl:equivalentClass [ rdf:type owl:Restriction ;
-                                                                                  owl:onProperty <http://material-digital.de/pmdao/tto/hasCharacteristic> ;
-                                                                                  owl:someValuesFrom [ owl:intersectionOf ( <http://material-digital.de/pmdao/tto/Norm>
-                                                                                                                            [ rdf:type owl:Restriction ;
-                                                                                                                              owl:onProperty <http://material-digital.de/pmdao/tto/hasValue> ;
-                                                                                                                              owl:hasValue "ISO6892-1"
-                                                                                                                            ]
-                                                                                                                          ) ;
-                                                                                                       rdf:type owl:Class
-                                                                                                     ]
-                                                                                ] ,
-                                                                                [ rdf:type owl:Restriction ;
-                                                                                  owl:onProperty <http://material-digital.de/pmdao/tto/hasParticipant> ;
-                                                                                  owl:someValuesFrom <http://material-digital.de/pmdao/tto/Extensometer>
-                                                                                ] ,
-                                                                                [ rdf:type owl:Restriction ;
-                                                                                  owl:onProperty <http://material-digital.de/pmdao/tto/hasParticipant> ;
-                                                                                  owl:someValuesFrom <http://material-digital.de/pmdao/tto/LoadCell>
-                                                                                ] ,
-                                                                                [ rdf:type owl:Restriction ;
-                                                                                  owl:onProperty <http://material-digital.de/pmdao/tto/hasParticipant> ;
-                                                                                  owl:someValuesFrom <http://material-digital.de/pmdao/tto/TensileTestingMachine>
-                                                                                ] ,
-                                                                                [ rdf:type owl:Restriction ;
-                                                                                  owl:onProperty <http://material-digital.de/pmdao/tto/hasParticipant> ;
-                                                                                  owl:someValuesFrom <http://material-digital.de/pmdao/tto/TestPiece>
-                                                                                ] ;
-                                                            rdfs:subClassOf <http://material-digital.de/pmdao/tto/TensileTest> ;
-                                                            rdfs:label "Tensile Test in accordance with ISO 6892-1"@en ,
-                                                                       "Zugversuch nach ISO 6892-1"@de .
-
-
-###  http://material-digital.de/pmdao/tto/Identifier
-<http://material-digital.de/pmdao/tto/Identifier> rdf:type owl:Class ;
-                                                  rdfs:subClassOf <http://material-digital.de/pmdao/tto/ValueObject> ;
-                                                  rdfs:label "Identifier"@en ,
-                                                             "Identifikator"@de ;
-                                                  <http://www.w3.org/2004/02/skos/core#definition> "A named value intended to distinguish between entities."@en .
-
-
-###  http://material-digital.de/pmdao/tto/Image
-<http://material-digital.de/pmdao/tto/Image> rdf:type owl:Class ;
-                                             rdfs:subClassOf <http://material-digital.de/pmdao/tto/Object> ;
-                                             <http://material-digital.de/pmdao/tto/definitionSource> "“Image.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/image. Accessed 25 Nov. 2022."@en ;
-                                             rdfs:label "Bild"@de ,
-                                                        "Image"@en ;
-                                             <http://www.w3.org/2004/02/skos/core#definition> "A visual representation of something"@en .
-
-
-###  http://material-digital.de/pmdao/tto/Index
-<http://material-digital.de/pmdao/tto/Index> rdf:type owl:Class ;
-                                             rdfs:subClassOf <http://material-digital.de/pmdao/tto/ValueObject> ;
-                                             rdfs:label "Index"@de ,
-                                                        "Index"@en ;
-                                             <http://www.w3.org/2004/02/skos/core#definition> "Some running number."@en .
-
-
-###  http://material-digital.de/pmdao/tto/Initiator
-<http://material-digital.de/pmdao/tto/Initiator> rdf:type owl:Class ;
-                                                 rdfs:subClassOf <http://www.w3.org/ns/prov#Person> ;
-                                                 rdfs:label "Initiator"@de ,
-                                                            "Initiator"@en ;
-                                                 <http://www.w3.org/2004/02/skos/core#definition> "The Person that commisioned the process."@en .
-
-
-###  http://material-digital.de/pmdao/tto/InsertSurface
-<http://material-digital.de/pmdao/tto/InsertSurface> rdf:type owl:Class ;
-                                                     rdfs:subClassOf <http://material-digital.de/pmdao/tto/QualifyingNodeAnnotation> ;
-                                                     <http://material-digital.de/pmdao/tto/definitionSource> "http://www.merriam-webster.com/dictionary/surface"@en ;
-                                                     rdfs:label "Insert Surface"@en ,
-                                                                "Oberfläche Eines Einsatzstücks"@de ;
-                                                     <http://www.w3.org/2004/02/skos/core#definition> "Diese Entität beschreibt den Zustand und die Qualität des Außenbereichs des Einsatzes eines Prozessknotens, z. B. die in Klemm- und Spannsystemen verwendeten Einsätze."@de ,
-                                                                                                      "This entity describes the state and quality of the exterior of the insert of a process node, e.g., the inserts used in grips."@en .
-
-
-###  http://material-digital.de/pmdao/tto/InspectionDocument
-<http://material-digital.de/pmdao/tto/InspectionDocument> rdf:type owl:Class ;
-                                                          rdfs:subClassOf <http://material-digital.de/pmdao/tto/Document> ;
-                                                          rdfs:label "Inspection Document"@en ,
-                                                                     "Inspektionsdokument"@de ;
-                                                          <http://www.w3.org/2004/02/skos/core#definition> "Diese Entität beschreibt ein Dokument, das Informationen über die Prüfung eines materiellen Objekts enthält, in der Regel versehen mit einem Prüfungsdatum, einem typischen Prüfungsintervall und dem Zustand des geprüften Objekts. Typischerweise wird ein solches Dokument für Prozessknoten verwendet."@de ,
-                                                                                                           "This entity describes a document used to give information on the examination of a tangible object, usually including an examination date, a typical examination interval and the state of the examined object. Typically, this is used for process nodes."@en .
-
-
-###  http://material-digital.de/pmdao/tto/IonicBond
-<http://material-digital.de/pmdao/tto/IonicBond> rdf:type owl:Class ;
-                                                 rdfs:subClassOf <http://material-digital.de/pmdao/tto/BondingType> ;
-                                                 <http://material-digital.de/pmdao/tto/definitionSource> "\"Ionic bond.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/ionic%20bond. Accessed 13 Jan. 2023."@en ;
-                                                 rdfs:label "Ionic Bond"@en ,
-                                                            "Ionische Bindung"@de ;
-                                                 <http://www.w3.org/2004/02/skos/core#definition> "Eine Ionenbindung ist eine chemische Bindung, die zwischen entgegengesetzt geladenen Stoffen aufgrund ihrer gegenseitigen elektrostatischen Anziehung entsteht."@de ,
-                                                                                                  "Ionic bond is a chemical bond formed between oppositely charged species because of their mutual electrostatic attraction."@en .
-
-
-###  http://material-digital.de/pmdao/tto/Laboratory
-<http://material-digital.de/pmdao/tto/Laboratory> rdf:type owl:Class ;
-                                                  rdfs:subClassOf <http://www.w3.org/ns/prov#Organization> ;
-                                                  <http://material-digital.de/pmdao/tto/definitionSource> "“Laboratory.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/laboratory. Accessed 24 Nov. 2022."@en ;
-                                                  rdfs:label "Labor"@de ,
-                                                             "Laboratory"@en ;
-                                                  <http://www.w3.org/2004/02/skos/core#definition> "A place equipped for experimental study in a science or for testing and analysis."@en .
-
-
-###  http://material-digital.de/pmdao/tto/Length
-<http://material-digital.de/pmdao/tto/Length> rdf:type owl:Class ;
-                                              rdfs:subClassOf <http://material-digital.de/pmdao/tto/ValueObject> ;
-                                              <http://material-digital.de/pmdao/tto/definitionSource> "http://www.merriam-webster.com/dictionary/length"@de ;
-                                              rdfs:label "Length"@en ,
-                                                         "Länge"@de ;
-                                              <http://www.w3.org/2004/02/skos/core#definition> "A measured distance or dimension of an object, usually the longer or longest dimension of the object."@en ,
-                                                                                               "Eine gemessene Entfernung oder Abmessung eines Objekts, normalerweise die längere oder längste Abmessung des Objekts."@de .
-
-
-###  http://material-digital.de/pmdao/tto/LoadCell
-<http://material-digital.de/pmdao/tto/LoadCell> rdf:type owl:Class ;
-                                                rdfs:subClassOf <http://material-digital.de/pmdao/tto/ProcessingNode> ;
-                                                <http://material-digital.de/pmdao/tto/definitionSource> "http://en.wikipedia.org/wiki/Load_cell"@en ;
-                                                rdfs:label "Kraftmessdose"@de ,
-                                                           "Load Cell"@en ;
-                                                <http://www.w3.org/2004/02/skos/core#definition> "A load cell converts a force such as tension, compression, pressure, or torque into an electrical signal that can be measured and standardized. It is a force transducer. As the force applied to the load cell increases, the electrical signal changes proportionally. The most common types of load cell are pneumatic, hydraulic, and strain gauges."@en .
-
-
-###  http://material-digital.de/pmdao/tto/Location
-<http://material-digital.de/pmdao/tto/Location> rdf:type owl:Class ;
-                                                rdfs:subClassOf <http://material-digital.de/pmdao/tto/ValueObject> ;
-                                                <http://material-digital.de/pmdao/tto/definitionSource> "“Location.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/location. Accessed 17 Jan. 2023."@en ;
-                                                rdfs:label "Location"@en ,
-                                                           "Ort"@de ;
-                                                <http://www.w3.org/2004/02/skos/core#definition> "A position or site occupied or available for occupancy or marked by some distinguishing feature."@en ,
-                                                                                                 "Eine Position oder ein Ort, der besetzt ist oder besetzt werden kann oder durch ein bestimmtes Merkmal gekennzeichnet ist."@de .
-
-
-###  http://material-digital.de/pmdao/tto/LowerYieldStrength
-<http://material-digital.de/pmdao/tto/LowerYieldStrength> rdf:type owl:Class ;
-                                                          owl:equivalentClass [ rdf:type owl:Restriction ;
-                                                                                owl:onProperty <http://material-digital.de/pmdao/tto/relatesTo> ;
-                                                                                owl:someValuesFrom <http://material-digital.de/pmdao/tto/Stress>
-                                                                              ] ;
-                                                          rdfs:subClassOf <http://material-digital.de/pmdao/tto/YieldStrength> ;
-                                                          <http://material-digital.de/pmdao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en ;
-                                                          rdfs:label "Lower Yield Strength"@en ,
-                                                                     "untere Streckgrenze"@de ;
-                                                          <http://www.w3.org/2004/02/skos/core#definition> "Symbol: R_eL"@en ,
-                                                                                                           "kleinste Spannung während des plastischen Fließens, wobei Einschwingerscheinungen nicht berücksichtigt werden"@de ,
-                                                                                                           "lowest value of stress during plastic yielding, ignoring any initial transient effects"@en .
-
-
-###  http://material-digital.de/pmdao/tto/Magnetic
-<http://material-digital.de/pmdao/tto/Magnetic> rdf:type owl:Class ;
-                                                rdfs:subClassOf <http://material-digital.de/pmdao/tto/MaterialProperty> ;
-                                                <http://material-digital.de/pmdao/tto/definitionSource> "“Magnetic.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/magnetic. Accessed 13 Jan. 2023."@en ;
-                                                rdfs:label "Magnetic"@en ,
-                                                           "Magnetisch"@de ;
-                                                <http://www.w3.org/2004/02/skos/core#definition> "Magnetic is relating relating to a magnet or to magnetism. Here specifically to the magnetic properties of a material."@en ,
-                                                                                                 "Magnetisch bezieht sich auf einen Magneten oder auf Magnetismus. Hier speziell auf die magnetischen Eigenschaften eines Materials."@de .
-
-
-###  http://material-digital.de/pmdao/tto/Manufacturer
-<http://material-digital.de/pmdao/tto/Manufacturer> rdf:type owl:Class ;
-                                                    rdfs:subClassOf <http://www.w3.org/ns/prov#Organization> ;
-                                                    rdfs:label "Hersteller"@de ,
-                                                               "Manufacturer"@en ;
-                                                    <http://www.w3.org/2004/02/skos/core#definition> "Process Node's manufacturer name, e.g.: \"Ipsen\", \"UPC\" or \"Bosch\""@en .
-
-
-###  http://material-digital.de/pmdao/tto/ManufacturingNode
-<http://material-digital.de/pmdao/tto/ManufacturingNode> rdf:type owl:Class ;
-                                                         rdfs:subClassOf <http://material-digital.de/pmdao/tto/ProcessingNode> ;
-                                                         rdfs:label "Herstellungsknoten"@de ,
-                                                                    "Manufacturing Node"@en ;
-                                                         <http://www.w3.org/2004/02/skos/core#definition> """A process node that implements transformative processes as well as consumes and creates tangible objects and typically requires inputs
-In general but not necessarily, a manufacture node includes intrinsic analysis nodes that create corresponding measurements with respect to the process implemented by the manufacture node."""@en .
-
-
-###  http://material-digital.de/pmdao/tto/ManufacturingProcess
-<http://material-digital.de/pmdao/tto/ManufacturingProcess> rdf:type owl:Class ;
-                                                            rdfs:subClassOf <http://material-digital.de/pmdao/tto/Process> ;
-                                                            rdfs:label "Herstellungsprozess"@de ,
-                                                                       "Manufacture Process"@en ;
-                                                            <http://www.w3.org/2004/02/skos/core#definition> """A process that is driven by the primary intent to transform objects
-A manufacture process is always a transformative process."""@en .
-
-
-###  http://material-digital.de/pmdao/tto/MaterialDesignation
-<http://material-digital.de/pmdao/tto/MaterialDesignation> rdf:type owl:Class ;
-                                                           rdfs:subClassOf <http://material-digital.de/pmdao/tto/MaterialRelated> ;
-                                                           rdfs:label "Material Designation"@en ,
-                                                                      "Materialbezeichnung"@de ;
-                                                           <http://www.w3.org/2004/02/skos/core#definition> """It is a name or identifier of a material type. It designates a material. 
-E.g. \"steel\", \"aluminium\", \"wood\", \"plastic\", \"rubber\".""" ;
-                                                           <http://www.w3.org/ns/prov#editorialNote> "former \"Material\" : \"It is a substance or mixture of substances that constitutes an object. represented by the sum of material properties and material structure\"" .
-
-
-###  http://material-digital.de/pmdao/tto/MaterialProperty
-<http://material-digital.de/pmdao/tto/MaterialProperty> rdf:type owl:Class ;
-                                                        rdfs:subClassOf <http://material-digital.de/pmdao/tto/MaterialRelated> ;
-                                                        <http://material-digital.de/pmdao/tto/definitionSource> "“List of materials properties.” Wikipedia The Free Encyclopedia, http://en.wikipedia.org/wiki/List_of_materials_properties. Accessed 13 Jan. 2023."@en ;
-                                                        rdfs:label "Material Property"@en ,
-                                                                   "Materialeigenschaft"@de ;
-                                                        <http://www.w3.org/2004/02/skos/core#definition> "A materials property is an intensive property of a material, i.e., a physical property that does not depend on the amount of the material. These quantitative properties may be used as a metric by which the benefits of one material versus another can be compared, thereby aiding in materials selection."@en ,
-                                                                                                         "Eine Materialeigenschaft ist eine intensive Eigenschaft eines Materials, d. h. eine physikalische Eigenschaft, die nicht von der Menge des Materials abhängt. Diese quantitativen Eigenschaften können als Maßstab verwendet werden, um die Vorteile eines Materials mit denen eines anderen zu vergleichen und so die Materialauswahl zu erleichtern."@de .
-
-
-###  http://material-digital.de/pmdao/tto/MaterialQuality
-<http://material-digital.de/pmdao/tto/MaterialQuality> rdf:type owl:Class ;
-                                                       rdfs:subClassOf <http://material-digital.de/pmdao/tto/MaterialRelated> ;
-                                                       rdfs:label "Material Quality"@en ,
-                                                                  "Materialqualität"@de ;
-                                                       <http://www.w3.org/2004/02/skos/core#definition> "i.e. Materialgüte"@de .
-
-
-###  http://material-digital.de/pmdao/tto/MaterialRelated
-<http://material-digital.de/pmdao/tto/MaterialRelated> rdf:type owl:Class ;
-                                                       rdfs:subClassOf <http://material-digital.de/pmdao/tto/ValueObject> ;
-                                                       rdfs:label "Material Related"@en ,
-                                                                  "Materialbezug"@de ;
-                                                       <http://www.w3.org/2004/02/skos/core#definition> "Diese Klasse dient der qualitativen und quantitativen Beschreibung eines Materials, indem sie Informationen über ein Material angibt, z. B. durch die Einbeziehung von Materialeigenschaften, Materialstruktur usw."@de ,
-                                                                                                        "This property is used to qualitatively and quantitatively describe a material by providing information on a material, e.g., by including material properties, material structure, etc."@en .
-
-
-###  http://material-digital.de/pmdao/tto/MaterialStructure
-<http://material-digital.de/pmdao/tto/MaterialStructure> rdf:type owl:Class ;
-                                                         rdfs:subClassOf <http://material-digital.de/pmdao/tto/MaterialRelated> ;
-                                                         <http://material-digital.de/pmdao/tto/definitionSource> "“Material - Classification by structure.” Wikipedia The Free Encyclopedia, http://en.wikipedia.org/wiki/Material#Classification_by_structure. Accessed 13 Jan. 2023."@en ;
-                                                         rdfs:label "Material Structure"@en ,
-                                                                    "Materialstruktur"@de ;
-                                                         <http://www.w3.org/2004/02/skos/core#definition> "Die relevante Struktur von Materialien hat je nach Material eine unterschiedliche Längenskala. Die Struktur und Zusammensetzung eines Materials kann durch Mikroskopie oder Spektroskopie bestimmt werden."@de ,
-                                                                                                          "The relevant structure of materials has a different length scale depending on the material. The structure and composition of a material can be determined by microscopy or spectroscopy."@en .
-
-
-###  http://material-digital.de/pmdao/tto/MaximumForce
-<http://material-digital.de/pmdao/tto/MaximumForce> rdf:type owl:Class ;
-                                                    rdfs:subClassOf <http://material-digital.de/pmdao/tto/Force> ;
-                                                    <http://material-digital.de/pmdao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en ;
-                                                    rdfs:label "Höchstkraft"@de ,
-                                                               "Maximum Force"@en ,
-                                                               "Symbol: F_m"@en ;
-                                                    <http://www.w3.org/2004/02/skos/core#definition> """Bei Werkstoffen, die kein diskontinuierliches Fließen zeigen: größte Kraft, der die Probe während des Versuchs standhält
-
-Bei Werkstoffen, die ein diskontinuierliches Fließen zeigen: größte Kraft, der die Probe während des Versuchs nach dem Beginn der Verfestigung standhält
-
-Anmerkung: Für Werkstoffe, die ein diskontinuierliches Fließen zeigen, aber keine Verfestigung erzielt werden kann, ist die Höchstkraft nicht definiert
-."""@de ,
-                                                                                                     """For materials displaying no discontinuous yielding: highest force that the test piece withstands during the test
-
-For materials displaying discontinuous yielding: highest force that the test piece withstands during the test after the beginning of work-hardening
-
-Note: For materials which display discontinuous yielding, but where no work-hardening can be established, the maximum force is not defined."""@en .
-
-
-###  http://material-digital.de/pmdao/tto/Measurement
-<http://material-digital.de/pmdao/tto/Measurement> rdf:type owl:Class ;
-                                                   rdfs:subClassOf <http://material-digital.de/pmdao/tto/ValueScope> ;
-                                                   owl:disjointWith <http://material-digital.de/pmdao/tto/SetPoint> ;
-                                                   <http://material-digital.de/pmdao/tto/definitionSource> "http://en.wikipedia.org/wiki/Measurement"@en ;
-                                                   rdfs:label "Measurement"@en ,
-                                                              "Messwert"@de ;
-                                                   <http://www.w3.org/2004/02/skos/core#definition> "Measurement is the quantification of attributes of an object or event, which can be used to compare with other objects or events."@en .
-
-
-###  http://material-digital.de/pmdao/tto/MeasuringDevice
-<http://material-digital.de/pmdao/tto/MeasuringDevice> rdf:type owl:Class ;
-                                                       rdfs:subClassOf <http://material-digital.de/pmdao/tto/ProcessingNode> ;
-                                                       rdfs:label "Measuring Device"@en ,
-                                                                  "Messgerät"@de ;
-                                                       <http://www.w3.org/2004/02/skos/core#definition> "A process node capable of determining a specific quality." .
-
-
-###  http://material-digital.de/pmdao/tto/MeasuringProcess
-<http://material-digital.de/pmdao/tto/MeasuringProcess> rdf:type owl:Class ;
-                                                        rdfs:subClassOf <http://material-digital.de/pmdao/tto/AnalysingProcess> ;
-                                                        rdfs:label "Measuring Process"@en ,
-                                                                   "Messprozess"@de ;
-                                                        <http://www.w3.org/2004/02/skos/core#definition> "A measurement process acquires data (usually expressed in numbers) by using tools."@en .
-
-
-###  http://material-digital.de/pmdao/tto/Mechanical
-<http://material-digital.de/pmdao/tto/Mechanical> rdf:type owl:Class ;
-                                                  rdfs:subClassOf <http://material-digital.de/pmdao/tto/MaterialProperty> ;
-                                                  <http://material-digital.de/pmdao/tto/definitionSource> "“Mechanical.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/mechanical. Accessed 13 Jan. 2023."@en ;
-                                                  rdfs:label "Mechanical"@en ,
-                                                             "Mechanisch"@de ;
-                                                  <http://www.w3.org/2004/02/skos/core#definition> "Mechanical is relating to, governed by, or in accordance with the principles of mechanics. Here specifically to the mechanical properties of a material."@en ,
-                                                                                                   "Mechanisch bedeutet, sich auf die Prinzipien der Mechanik zu beziehen, von ihnen beherrscht zu werden oder sie zu befolgen. Hier speziell auf die mechanischen Eigenschaften eines Materials."@de .
-
-
-###  http://material-digital.de/pmdao/tto/MechanicalTestingProcess
-<http://material-digital.de/pmdao/tto/MechanicalTestingProcess> rdf:type owl:Class ;
-                                                                rdfs:subClassOf <http://material-digital.de/pmdao/tto/AnalysingProcess> ;
-                                                                <http://material-digital.de/pmdao/tto/definitionSource> "“Mechanical test.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/mechanical%20test. Accessed 24 Nov. 2022."@en ;
-                                                                rdfs:label "Mechanical Testing Process"@en ,
-                                                                           "Mechanischer Testprozess"@de ;
-                                                                <http://www.w3.org/2004/02/skos/core#definition> "Determinization of a mechanical property."@en .
-
-
-###  http://material-digital.de/pmdao/tto/Medium
-<http://material-digital.de/pmdao/tto/Medium> rdf:type owl:Class ;
-                                              rdfs:subClassOf <http://material-digital.de/pmdao/tto/Object> ;
-                                              rdfs:label "Medium"@de ,
-                                                         "Medium"@en ;
-                                              <http://www.w3.org/2004/02/skos/core#definition> "Substance that surrounds an object inside the system boundaries of a process node."@en .
-
-
-###  http://material-digital.de/pmdao/tto/Metadata
-<http://material-digital.de/pmdao/tto/Metadata> rdf:type owl:Class ;
-                                                rdfs:subClassOf <http://material-digital.de/pmdao/tto/DataScope> ,
-                                                                <http://material-digital.de/pmdao/tto/ValueObject> ;
-                                                owl:disjointWith <http://material-digital.de/pmdao/tto/PrimaryData> ,
-                                                                 <http://material-digital.de/pmdao/tto/SecondaryData> ;
-                                                rdfs:label "Metadata"@en ,
-                                                           "Metadaten"@de ;
-                                                <http://www.w3.org/2004/02/skos/core#definition> "Attributes and additional data (provenance) concerning the factory, laboratory, the process system and the objects which allow the evaluation of the quality / reliability of the measurements and a systematic search task of a database."@en .
-
-
-###  http://material-digital.de/pmdao/tto/MetallicBond
-<http://material-digital.de/pmdao/tto/MetallicBond> rdf:type owl:Class ;
-                                                    rdfs:subClassOf <http://material-digital.de/pmdao/tto/BondingType> ;
-                                                    <http://material-digital.de/pmdao/tto/definitionSource> "\"Metallic bond.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/metallic%20bond. Accessed 13 Jan. 2023."@en ;
-                                                    rdfs:label "Metallbindung"@de ,
-                                                               "Metallic Bond"@en ;
-                                                    <http://www.w3.org/2004/02/skos/core#definition> "Metallic bond is the chemical bond typical of the metallic state and characterized by mobile valence electrons that hold the atoms together usually in crystal lattices and are responsible for the good electrical and heat conductivity of metals."@en ,
-                                                                                                     "Metallische Bindung ist die für den metallischen Zustand typische chemische Bindung, die durch bewegliche Valenzelektronen gekennzeichnet ist, die die Atome in der Regel in Kristallgittern zusammenhalten und für die gute elektrische und Wärmeleitfähigkeit von Metallen verantwortlich sind."@de .
-
-
-###  http://material-digital.de/pmdao/tto/Method
-<http://material-digital.de/pmdao/tto/Method> rdf:type owl:Class ;
-                                              rdfs:subClassOf <http://material-digital.de/pmdao/tto/ValueObject> ;
-                                              owl:disjointWith <http://material-digital.de/pmdao/tto/Process> ;
-                                              <http://material-digital.de/pmdao/tto/definitionSource> "“Method.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/method. Accessed 5 Dec. 2022."@en ;
-                                              rdfs:label "Method"@en ,
-                                                         "Methode"@de ;
-                                              <http://www.w3.org/2004/02/skos/core#definition> "A way, technique, or process of or for doing something"@en .
-
-
-###  http://material-digital.de/pmdao/tto/MicrometerGauge
-<http://material-digital.de/pmdao/tto/MicrometerGauge> rdf:type owl:Class ;
-                                                       rdfs:subClassOf <http://material-digital.de/pmdao/tto/MeasuringDevice> ;
-                                                       <http://material-digital.de/pmdao/tto/definitionSource> "http://www.merriam-webster.com/dictionary/micrometer%20caliper"@en ;
-                                                       rdfs:label "Bügelmessschraube"@de ,
-                                                                  "Micrometer Gauge"@en ;
-                                                       <http://www.w3.org/2004/02/skos/core#definition> "Diese Entität beschreibt ein Werkzeug zur Durchführung präziser Messungen mit einer Spindel, die durch eine Feingewindeschraube bewegt wird."@de ,
-                                                                                                        "This entity describes a tool for making precise measurements having a spindle moved by a finely threaded screw."@en .
-
-
-###  http://material-digital.de/pmdao/tto/ModulusOfElasticity
-<http://material-digital.de/pmdao/tto/ModulusOfElasticity> rdf:type owl:Class ;
-                                                           rdfs:subClassOf <http://material-digital.de/pmdao/tto/ValueObject> ;
-                                                           <http://material-digital.de/pmdao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en ;
-                                                           rdfs:label "Elastizitätsmodul"@de ,
-                                                                      "Modulus Of Elasticity"@en ;
-                                                           <http://www.w3.org/2004/02/skos/core#definition> """Quotient der Änderung der Spannung ΔR und Änderung der prozentualen Dehnung Δe in dem untersuchten Bereich multipliziert mit 100 % 
-
-Anmerkung: Es wird empfohlen, den Wert in GPa, gerundet auf 0,1 GPa, und nach ISO 80000-1 anzugeben."""@de ,
-                                                                                                            "Symbol: E"@en ,
-                                                                                                            """quotient of change of stress ΔR and change of percentage extension Δe in the range of evaluation, multiplied by 100 %
-
-Note: It is recommended to report the value in GPa rounded to the nearest 0.1 GPa and according to ISO 80000-1."""@en .
-
-
-###  http://material-digital.de/pmdao/tto/MountingProcess
-<http://material-digital.de/pmdao/tto/MountingProcess> rdf:type owl:Class ;
-                                                       rdfs:subClassOf <http://material-digital.de/pmdao/tto/AssemblingProcess> ;
-                                                       owl:disjointWith <http://material-digital.de/pmdao/tto/TemperatureChangingProcess> ;
-                                                       rdfs:label "Montageprozess"@de ,
-                                                                  "Mounting Process"@en ;
-                                                       <http://www.w3.org/2004/02/skos/core#definition> "This property is used to describe the process of installing, assembling oder otherwise incorporating a test piece or specimen into a test machine. This may include the usage of other process nodes (e.g. grips)."@en .
-
-
-###  http://material-digital.de/pmdao/tto/NodeInfo
-<http://material-digital.de/pmdao/tto/NodeInfo> rdf:type owl:Class ;
-                                                rdfs:subClassOf <http://material-digital.de/pmdao/tto/ValueObject> ;
-                                                rdfs:label "Knoteninformation"@de ,
-                                                           "Node Info"@en ;
-                                                <http://www.w3.org/2004/02/skos/core#definition> "Descriptive values to specify a process node."@en .
-
-
-###  http://material-digital.de/pmdao/tto/NodeModel
-<http://material-digital.de/pmdao/tto/NodeModel> rdf:type owl:Class ;
-                                                 rdfs:subClassOf <http://material-digital.de/pmdao/tto/NodeInfo> ;
-                                                 rdfs:label "Knotenmodell"@de ,
-                                                            "Node Model"@en ;
-                                                 <http://www.w3.org/2004/02/skos/core#definition> "Process Node short description, e.g. \"Vacuum Furnace\""@en .
-
-
-###  http://material-digital.de/pmdao/tto/NodeName
-<http://material-digital.de/pmdao/tto/NodeName> rdf:type owl:Class ;
-                                                rdfs:subClassOf <http://material-digital.de/pmdao/tto/NodeInfo> ;
-                                                rdfs:label "Knotenname"@de ,
-                                                           "Node Name"@en ;
-                                                <http://www.w3.org/2004/02/skos/core#definition> "A human-generated identifier associated with a discernible, tangible or simulated entity intended to be unique in a given scope"@en .
-
-
-###  http://material-digital.de/pmdao/tto/NodeSerialNumber
-<http://material-digital.de/pmdao/tto/NodeSerialNumber> rdf:type owl:Class ;
-                                                        rdfs:subClassOf <http://material-digital.de/pmdao/tto/NodeInfo> ;
-                                                        rdfs:label "Knoten-Seriennummer"@de ,
-                                                                   "Node Serial Number"@en ;
-                                                        <http://www.w3.org/2004/02/skos/core#definition> "A unique identifier of a process node, typically provided by the manufacturer (manufacturer serial number,  s/n)."@en .
-
-
-###  http://material-digital.de/pmdao/tto/NodeType
-<http://material-digital.de/pmdao/tto/NodeType> rdf:type owl:Class ;
-                                                rdfs:subClassOf <http://material-digital.de/pmdao/tto/NodeInfo> ;
-                                                rdfs:label "Knotentyp"@de ,
-                                                           "Node Type"@en ;
-                                                <http://www.w3.org/2004/02/skos/core#definition> "Process Node typename, e.g. \"ProTherm500\""@en .
-
-
-###  http://material-digital.de/pmdao/tto/NodeVersion
-<http://material-digital.de/pmdao/tto/NodeVersion> rdf:type owl:Class ;
-                                                   rdfs:subClassOf <http://material-digital.de/pmdao/tto/NodeInfo> ;
-                                                   rdfs:label "Knotenversion"@de ,
-                                                              "Node Version"@en ;
-                                                   <http://www.w3.org/2004/02/skos/core#definition> "Process Node Version Number, e.g. \"2.24\""@en .
-
-
-###  http://material-digital.de/pmdao/tto/NonTransformativeAnalysisProcess
-<http://material-digital.de/pmdao/tto/NonTransformativeAnalysisProcess> rdf:type owl:Class ;
-                                                                        rdfs:subClassOf <http://material-digital.de/pmdao/tto/AnalysingProcess> ;
-                                                                        owl:disjointWith <http://material-digital.de/pmdao/tto/TransformativeAnalysisProcess> ;
-                                                                        rdfs:label "Nicht-transformativer Analyseprozess"@de ,
-                                                                                   "Non Transformative Analysis Process"@en ;
-                                                                        <http://www.w3.org/2004/02/skos/core#definition> "An analysis process that is also a non-transformative process"@en .
-
-
-###  http://material-digital.de/pmdao/tto/Norm
-<http://material-digital.de/pmdao/tto/Norm> rdf:type owl:Class ;
-                                            rdfs:subClassOf <http://material-digital.de/pmdao/tto/Method> ;
-                                            <http://material-digital.de/pmdao/tto/definitionSource> "“Norm.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/norm. Accessed 24 Nov. 2022."@en ;
-                                            rdfs:label "Norm"@de ,
-                                                       "Norm"@en ;
-                                            <http://www.w3.org/2004/02/skos/core#definition> "An authoritative standard."@en ;
-                                            <http://www.w3.org/2004/02/skos/core#example> "Technical standard issued by the German Institute for Standardisation Registered Association (Deutsches Institut für Normung e.V. - DIN)"@en .
-
-
-###  http://material-digital.de/pmdao/tto/Note
-<http://material-digital.de/pmdao/tto/Note> rdf:type owl:Class ;
-                                            rdfs:subClassOf <http://material-digital.de/pmdao/tto/ValueObject> ;
-                                            rdfs:label "Bemerkung"@de ,
-                                                       "Note"@en ,
-                                                       "Notiz"@de ;
-                                            <http://www.w3.org/2004/02/skos/core#definition> "Additional information & knowledge for and by humans. Not expected to be parsable"@en .
-
-
-###  http://material-digital.de/pmdao/tto/Object
-<http://material-digital.de/pmdao/tto/Object> rdf:type owl:Class ;
-                                              rdfs:subClassOf <http://www.w3.org/ns/prov#Entity> ;
-                                              rdfs:label "Object"@en ,
-                                                         "Objekt"@de ;
-                                              <http://www.w3.org/2004/02/skos/core#definition> "A discernable, tangible or simulated entity that is processed in a process by a process node."@en .
-
-
-###  http://material-digital.de/pmdao/tto/Operator
-<http://material-digital.de/pmdao/tto/Operator> rdf:type owl:Class ;
-                                                rdfs:subClassOf <http://www.w3.org/ns/prov#Person> ;
-                                                <http://material-digital.de/pmdao/tto/definitionSource> "“Operator.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/operator. Accessed 24 Nov. 2022."@en ;
-                                                rdfs:label "Operator"@de ,
-                                                           "Operator"@en ;
-                                                <http://www.w3.org/2004/02/skos/core#definition> "A person that operates a machine or device."@en .
-
-
-###  http://material-digital.de/pmdao/tto/Optical
-<http://material-digital.de/pmdao/tto/Optical> rdf:type owl:Class ;
-                                               rdfs:subClassOf <http://material-digital.de/pmdao/tto/MaterialProperty> ;
-                                               <http://material-digital.de/pmdao/tto/definitionSource> "“Optical.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/optical. Accessed 13 Jan. 2023."@en ;
-                                               rdfs:label "Optical"@en ,
-                                                          "Optisch"@de ;
-                                               <http://www.w3.org/2004/02/skos/core#definition> "Optical is relating to the science of optics. Here specifically to the optical properties of a material."@en ,
-                                                                                                "Optisch bezieht sich auf die Wissenschaft der Optik. Hier speziell auf die optischen Eigenschaften eines Materials."@de .
-
-
-###  http://material-digital.de/pmdao/tto/OriginalDiameter
-<http://material-digital.de/pmdao/tto/OriginalDiameter> rdf:type owl:Class ;
-                                                        rdfs:subClassOf <http://material-digital.de/pmdao/tto/Diameter> ;
-                                                        <http://material-digital.de/pmdao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en ;
-                                                        rdfs:label "Anfangs-Probendurchmesser"@de ,
-                                                                   "Original Diameter"@en ;
-                                                        <http://www.w3.org/2004/02/skos/core#definition> "Die Länge einer geraden Linie durch den Mittelpunkt eines Objekts (Prüfkörpers), die vor einer Prüfung gemessen wird."@de ,
-                                                                                                         "The length of a straight line through the center of an object (test piece) as measured before a test."@en .
-
-
-###  http://material-digital.de/pmdao/tto/OriginalGaugeLength
-<http://material-digital.de/pmdao/tto/OriginalGaugeLength> rdf:type owl:Class ;
-                                                           rdfs:subClassOf <http://material-digital.de/pmdao/tto/GaugeLength> ;
-                                                           <http://material-digital.de/pmdao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en ;
-                                                           rdfs:label "Anfangsmesslänge"@de ,
-                                                                      "Original Gauge Length"@en ;
-                                                           <http://www.w3.org/2004/02/skos/core#definition> "Länge zwischen den Marken zur Kennzeichnung der Messlänge auf der Probe, die vor dem Versuch bei Raumtemperatur gemessen wird"@de ,
-                                                                                                            "Symbol: L_o"@en ,
-                                                                                                            "length between gauge length marks on the test piece measured at room temperature before the test"@en .
-
-
-###  http://material-digital.de/pmdao/tto/OriginalThickness
-<http://material-digital.de/pmdao/tto/OriginalThickness> rdf:type owl:Class ;
-                                                         rdfs:subClassOf <http://material-digital.de/pmdao/tto/Length> ;
-                                                         rdfs:label "Anfangs-Dicke"@de ,
-                                                                    "Original Thickness"@en ;
-                                                         <http://www.w3.org/2004/02/skos/core#definition> "Diese Eigenschaft beschreibt die gemessene Dimension in einer Richtung eines Prüfstücks, wie sie vor der Prüfung gemessen wurde."@de ,
-                                                                                                          "This property describes the measured dimension in one direction of a test piece, as measured before the test."@en .
-
-
-###  http://material-digital.de/pmdao/tto/OriginalWidth
-<http://material-digital.de/pmdao/tto/OriginalWidth> rdf:type owl:Class ;
-                                                     rdfs:subClassOf <http://material-digital.de/pmdao/tto/Width> ;
-                                                     rdfs:label "Anfangs-Breite"@de ,
-                                                                "Original Width"@en ;
-                                                     <http://www.w3.org/2004/02/skos/core#definition> "Diese Eigenschaft beschreibt eine horizontale Messung eines Objekts (Prüfkörpers) im rechten Winkel zur Länge des Objekts (Prüfkörpers), wie sie vor einer Prüfung gemessen wird."@de ,
-                                                                                                      "This property describes a horizontal measurement of an object (test piece) taken at right angles to the length of the object (test piece), as measured before a test."@en .
-
-
-###  http://material-digital.de/pmdao/tto/ParallelLength
-<http://material-digital.de/pmdao/tto/ParallelLength> rdf:type owl:Class ;
-                                                      rdfs:subClassOf <http://material-digital.de/pmdao/tto/Length> ;
-                                                      <http://material-digital.de/pmdao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en ;
-                                                      rdfs:label "Parallel Length"@en ,
-                                                                 "Parallele Länge"@de ;
-                                                      <http://www.w3.org/2004/02/skos/core#definition> """Länge des parallelen reduzierten Querschnitts der Probe
-
-Anmerkung: Bei unbearbeiteten Proben tritt an die Stelle der parallelen Länge der Abstand zwischen den Einspannungen."""@de ,
-                                                                                                       "Symbol: L_c"@en ,
-                                                                                                       """length of the parallel reduced section of the test piece
-
-Note: The concept of parallel length is replaced by the concept of distance between grips for unmachined test pieces."""@en .
-
-
-###  http://material-digital.de/pmdao/tto/PercentageElongation
-<http://material-digital.de/pmdao/tto/PercentageElongation> rdf:type owl:Class ;
-                                                            owl:equivalentClass [ rdf:type owl:Restriction ;
-                                                                                  owl:onProperty <http://material-digital.de/pmdao/tto/relatesTo> ;
-                                                                                  owl:someValuesFrom <http://material-digital.de/pmdao/tto/OriginalGaugeLength>
-                                                                                ] ;
-                                                            rdfs:subClassOf <http://material-digital.de/pmdao/tto/Elongation> ;
-                                                            <http://material-digital.de/pmdao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en ;
-                                                            rdfs:label "Dehnung"@de ,
-                                                                       "Percentage Elongation"@en ;
-                                                            <http://www.w3.org/2004/02/skos/core#definition> "Verlängerung, angegeben in Prozent, bezogen auf die Anfangsmesslänge"@de ,
-                                                                                                             "elongation expressed as a percentage of the original gauge length"@en .
-
-
-###  http://material-digital.de/pmdao/tto/PercentageElongationAfterFracture
-<http://material-digital.de/pmdao/tto/PercentageElongationAfterFracture> rdf:type owl:Class ;
-                                                                         owl:equivalentClass [ rdf:type owl:Restriction ;
-                                                                                               owl:onProperty <http://material-digital.de/pmdao/tto/relatesTo> ;
-                                                                                               owl:someValuesFrom <http://material-digital.de/pmdao/tto/OriginalGaugeLength>
-                                                                                             ] ;
-                                                                         rdfs:subClassOf <http://material-digital.de/pmdao/tto/Elongation> ;
-                                                                         <http://material-digital.de/pmdao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en ;
-                                                                         rdfs:label "Bruchdehnung"@de ,
-                                                                                    "Percentage Elongation After Fracture"@en ;
-                                                                         <http://www.w3.org/2004/02/skos/core#definition> "Symbol: A"@en ,
-                                                                                                                          "bleibende Verlängerung der Messlänge nach dem Bruch (L_u − L_o), angegeben in Prozent, bezogen auf die Anfangsmesslänge"@de ,
-                                                                                                                          "permanent elongation of the gauge length after fracture (L_u − L_o), expressed as a percentage of the original gauge length"@en .
-
-
-###  http://material-digital.de/pmdao/tto/PercentageExtension
-<http://material-digital.de/pmdao/tto/PercentageExtension> rdf:type owl:Class ;
-                                                           owl:equivalentClass [ rdf:type owl:Restriction ;
-                                                                                 owl:onProperty <http://material-digital.de/pmdao/tto/relatesTo> ;
-                                                                                 owl:someValuesFrom <http://material-digital.de/pmdao/tto/ExtensometerGaugeLength>
-                                                                               ] ;
-                                                           rdfs:subClassOf <http://material-digital.de/pmdao/tto/Extension> ;
-                                                           <http://material-digital.de/pmdao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en ;
-                                                           rdfs:label "Extensometer-Dehnung"@de ,
-                                                                      "Percentage Extension"@en ;
-                                                           <http://www.w3.org/2004/02/skos/core#definition> "Synonym: (engineering) strain"@en ,
-                                                                                                            "Synonym: technische Dehnung"@de ,
-                                                                                                            """extension expressed as a percentage of the extensometer gauge length
-
-Note: The percentage extension is commonly called engineering strain."""@en ,
-                                                                                                            """in Prozent angegebene Verlängerung der Extensometer-Messlänge
-
-Anmerkung: Die Extensometer-Dehnung wird oftmals auch als technische Dehnung bezeichnet."""@de .
-
-
-###  http://material-digital.de/pmdao/tto/PercentagePermanentElongation
-<http://material-digital.de/pmdao/tto/PercentagePermanentElongation> rdf:type owl:Class ;
-                                                                     owl:equivalentClass [ rdf:type owl:Restriction ;
-                                                                                           owl:onProperty <http://material-digital.de/pmdao/tto/relatesTo> ;
-                                                                                           owl:someValuesFrom <http://material-digital.de/pmdao/tto/OriginalGaugeLength>
-                                                                                         ] ;
-                                                                     rdfs:subClassOf <http://material-digital.de/pmdao/tto/Elongation> ;
-                                                                     <http://material-digital.de/pmdao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en ;
-                                                                     rdfs:label "Bleibende Dehnung"@de ,
-                                                                                "Percentage Permanent Elongation"@en ;
-                                                                     <http://www.w3.org/2004/02/skos/core#definition> "Zunahme der Anfangsmesslänge einer Probe nach Entfernen einer festgelegten Zugspannung, angegeben in Prozent, bezogen auf die Anfangsmesslänge"@de ,
-                                                                                                                      "increase in the original gauge length of a test piece after removal of a specified stress, expressed as a percentage of the original gauge length"@en .
-
-
-###  http://material-digital.de/pmdao/tto/PercentagePermanentExtension
-<http://material-digital.de/pmdao/tto/PercentagePermanentExtension> rdf:type owl:Class ;
-                                                                    owl:equivalentClass [ rdf:type owl:Restriction ;
-                                                                                          owl:onProperty <http://material-digital.de/pmdao/tto/relatesTo> ;
-                                                                                          owl:someValuesFrom <http://material-digital.de/pmdao/tto/ExtensometerGaugeLength>
-                                                                                        ] ;
-                                                                    rdfs:subClassOf <http://material-digital.de/pmdao/tto/Extension> ;
-                                                                    <http://material-digital.de/pmdao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en ;
-                                                                    rdfs:label "Bleibende Extensometer-Dehnung"@de ,
-                                                                               "Percentage Permanent Extension"@en ;
-                                                                    <http://www.w3.org/2004/02/skos/core#definition> "Vergrößerung der Extensometer-Messlänge nach Entfernen einer festgelegten, auf die Probe aufgebrachten Zugspannung, angegeben in Prozent, bezogen auf die Extensometer-Messlänge"@de ,
-                                                                                                                     "increase in the extensometer gauge length, after removal of a specified stress from the test piece, expressed as a percentage of the extensometer gauge length"@en .
-
-
-###  http://material-digital.de/pmdao/tto/PercentagePlasticExtensionAtMaximumForce
-<http://material-digital.de/pmdao/tto/PercentagePlasticExtensionAtMaximumForce> rdf:type owl:Class ;
-                                                                                owl:equivalentClass [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
-                                                                                                                             owl:onProperty <http://material-digital.de/pmdao/tto/relatesTo> ;
-                                                                                                                             owl:someValuesFrom <http://material-digital.de/pmdao/tto/ExtensometerGaugeLength>
-                                                                                                                           ]
-                                                                                                                           [ rdf:type owl:Restriction ;
-                                                                                                                             owl:onProperty <http://material-digital.de/pmdao/tto/relatesTo> ;
-                                                                                                                             owl:someValuesFrom <http://material-digital.de/pmdao/tto/MaximumForce>
-                                                                                                                           ]
-                                                                                                                         ) ;
-                                                                                                      rdf:type owl:Class
-                                                                                                    ] ;
-                                                                                rdfs:subClassOf <http://material-digital.de/pmdao/tto/Extension> ;
-                                                                                <http://material-digital.de/pmdao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en ;
-                                                                                rdfs:label "Percentage Plastic Extension At Maximum Force"@en ,
-                                                                                           "Plastische Extensometer-Dehnung bei Höchstkraft"@de ;
-                                                                                <http://www.w3.org/2004/02/skos/core#definition> "Symbol: A_g"@en ,
-                                                                                                                                 "plastic extension at maximum force, expressed as a percentage of the extensometer gauge length"@en ,
-                                                                                                                                 "plastische Verlängerung der Extensometer-Messlänge bei Höchstkraft, angegeben in Prozent, bezogen auf die Extensometer-Messlänge"@de .
-
-
-###  http://material-digital.de/pmdao/tto/PercentageReductionOfArea
-<http://material-digital.de/pmdao/tto/PercentageReductionOfArea> rdf:type owl:Class ;
-                                                                 owl:equivalentClass [ rdf:type owl:Class ;
-                                                                                       owl:unionOf ( [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
-                                                                                                                              owl:onProperty <http://material-digital.de/pmdao/tto/relatesTo> ;
-                                                                                                                              owl:someValuesFrom <http://material-digital.de/pmdao/tto/OriginalThickness>
-                                                                                                                            ]
-                                                                                                                            [ rdf:type owl:Restriction ;
-                                                                                                                              owl:onProperty <http://material-digital.de/pmdao/tto/relatesTo> ;
-                                                                                                                              owl:someValuesFrom <http://material-digital.de/pmdao/tto/OriginalWidth>
-                                                                                                                            ]
-                                                                                                                          ) ;
-                                                                                                       rdf:type owl:Class
-                                                                                                     ]
-                                                                                                     [ rdf:type owl:Restriction ;
-                                                                                                       owl:onProperty <http://material-digital.de/pmdao/tto/relatesTo> ;
-                                                                                                       owl:someValuesFrom <http://material-digital.de/pmdao/tto/OriginalDiameter>
-                                                                                                     ]
-                                                                                                   )
-                                                                                     ] ;
-                                                                 rdfs:subClassOf <http://material-digital.de/pmdao/tto/ValueObject> ;
-                                                                 <http://material-digital.de/pmdao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en ;
-                                                                 rdfs:label "Brucheinschnürung"@de ,
-                                                                            "Percentage Reduction Of Area"@en ;
-                                                                 <http://www.w3.org/2004/02/skos/core#definition> "Symbol: Z"@en ,
-                                                                                                                  "größte während des Versuchs aufgetretene Änderung des Querschnitts (S_o − S_u), angegeben in Prozent, bezogen auf den Anfangsquerschnitt S_o"@de ,
-                                                                                                                  "maximum change in cross-sectional area which has occurred during the test (S_o − S_u), expressed as a percentage of the original cross-sectional area, S_o"@en .
-
-
-###  http://material-digital.de/pmdao/tto/PercentageTotalExtensionAtFracture
-<http://material-digital.de/pmdao/tto/PercentageTotalExtensionAtFracture> rdf:type owl:Class ;
-                                                                          owl:equivalentClass [ rdf:type owl:Restriction ;
-                                                                                                owl:onProperty <http://material-digital.de/pmdao/tto/relatesTo> ;
-                                                                                                owl:someValuesFrom <http://material-digital.de/pmdao/tto/ExtensometerGaugeLength>
-                                                                                              ] ;
-                                                                          rdfs:subClassOf <http://material-digital.de/pmdao/tto/Extension> ;
-                                                                          <http://material-digital.de/pmdao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en ;
-                                                                          rdfs:label "Gesamte Extensometer-Dehnung beim Bruch"@de ,
-                                                                                     "Percentage Total Extension At Fracture"@en ;
-                                                                          <http://www.w3.org/2004/02/skos/core#definition> "Symbol: A_t"@en ,
-                                                                                                                           "gesamte Verlängerung (elastische plus plastische Verlängerung) der Extensometer-Messlänge beim Bruch, angegeben in Prozent, bezogen auf die Extensometer-Messlänge"@de ,
-                                                                                                                           "total extension (elastic extension plus plastic extension) at the moment of fracture, expressed as a percentage of the extensometer gauge length"@en .
-
-
-###  http://material-digital.de/pmdao/tto/PercentageTotalExtensionAtMaximumForce
-<http://material-digital.de/pmdao/tto/PercentageTotalExtensionAtMaximumForce> rdf:type owl:Class ;
-                                                                              owl:equivalentClass [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
-                                                                                                                           owl:onProperty <http://material-digital.de/pmdao/tto/relatesTo> ;
-                                                                                                                           owl:someValuesFrom <http://material-digital.de/pmdao/tto/ExtensometerGaugeLength>
-                                                                                                                         ]
-                                                                                                                         [ rdf:type owl:Restriction ;
-                                                                                                                           owl:onProperty <http://material-digital.de/pmdao/tto/relatesTo> ;
-                                                                                                                           owl:someValuesFrom <http://material-digital.de/pmdao/tto/MaximumForce>
-                                                                                                                         ]
-                                                                                                                       ) ;
-                                                                                                    rdf:type owl:Class
-                                                                                                  ] ;
-                                                                              rdfs:subClassOf <http://material-digital.de/pmdao/tto/Extension> ;
-                                                                              <http://material-digital.de/pmdao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en ;
-                                                                              rdfs:label "Gesamte Extensometer-Dehnung bei Höchstkraft"@de ,
-                                                                                         "Percentage Total Extension At Maximum Force"@en ;
-                                                                              <http://www.w3.org/2004/02/skos/core#definition> "Symbol: A_gt"@en ,
-                                                                                                                               "gesamte Verlängerung (elastische plus plastische Verlängerung) der Extensometer-Messlänge bei Höchstkraft, angegeben in Prozent, bezogen auf die Extensometer-Messlänge"@de ,
-                                                                                                                               "total extension (elastic extension plus plastic extension) at maximum force, expressed as a percentage of the extensometer gauge length"@en .
-
-
-###  http://material-digital.de/pmdao/tto/PercentageYieldPointExtension
-<http://material-digital.de/pmdao/tto/PercentageYieldPointExtension> rdf:type owl:Class ;
-                                                                     rdfs:subClassOf <http://material-digital.de/pmdao/tto/Extension> ;
-                                                                     <http://material-digital.de/pmdao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en ;
-                                                                     rdfs:label "Percentage Yield Point Extension"@en ,
-                                                                                "Streckgrenzen-Extensometer-Dehnung"@de ;
-                                                                     <http://www.w3.org/2004/02/skos/core#definition> "Bei Werkstoffen, die ein diskontinuierliches Fließen zeigen: Verlängerung der Extensometer-Messlänge zwischen dem Beginn örtlichen Fließens und dem Einsetzen gleichmäßiger Verfestigung, angegeben in Prozent, bezogen auf die Extensometer-Messlänge"@de ,
-                                                                                                                      "For discontinuous yielding materials: extension between the start of yielding and the start of uniform work-hardening, expressed as a percentage of the extensometer gauge length"@en ,
-                                                                                                                      "Symbol: A_e"@en .
-
-
-###  http://material-digital.de/pmdao/tto/Perimeter
-<http://material-digital.de/pmdao/tto/Perimeter> rdf:type owl:Class ;
-                                                 rdfs:subClassOf <http://material-digital.de/pmdao/tto/ValueObject> ;
-                                                 rdfs:label "Perimeter"@en ,
-                                                            "Umfang"@de ;
-                                                 <http://www.w3.org/2004/02/skos/core#definition> "Der Durchmesser einer zweidimensionalen Form."@de ,
-                                                                                                  "The perimeter of a two-dimensional shape is defined as the path or boundary that encloses the shape."@en .
-
-
-###  http://material-digital.de/pmdao/tto/Precision
-<http://material-digital.de/pmdao/tto/Precision> rdf:type owl:Class ;
-                                                 rdfs:subClassOf <http://material-digital.de/pmdao/tto/ValueObject> ;
-                                                 <http://material-digital.de/pmdao/tto/definitionSource> "“Precision.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/precision. Accessed 13 Jan. 2023."@en ;
-                                                 rdfs:label "Genauigkeit"@de ,
-                                                            "Precision"@en ;
-                                                 <http://www.w3.org/2004/02/skos/core#definition> "Der Grad der Verfeinerung, mit dem eine Operation durchgeführt oder eine Messung angegeben wird."@de ,
-                                                                                                  "The degree of refinement with which an operation is performed or a measurement stated."@en .
-
-
-###  http://material-digital.de/pmdao/tto/PrimaryData
-<http://material-digital.de/pmdao/tto/PrimaryData> rdf:type owl:Class ;
-                                                   rdfs:subClassOf <http://material-digital.de/pmdao/tto/DataScope> ;
-                                                   owl:disjointWith <http://material-digital.de/pmdao/tto/SecondaryData> ;
-                                                   rdfs:label "Primary Data"@en ,
-                                                              "Primärdaten"@de ;
-                                                   <http://www.w3.org/2004/02/skos/core#definition> "Data acquired before / after a process either refering to the geometry of the object (e.g. ao, bo, do, au, bu, du, Lu) or as a register of the complete setup (e.g. sketches, photos or videos)"@en ,
-                                                                                                    "Data directly acquired during a process by sensors (time, force, length, temperature)"@en .
-
-
-###  http://material-digital.de/pmdao/tto/Process
-<http://material-digital.de/pmdao/tto/Process> rdf:type owl:Class ;
-                                               rdfs:subClassOf <http://www.w3.org/ns/prov#Activity> ;
-                                               rdfs:label "Process"@en ,
-                                                          "Prozess"@de ;
-                                               <http://www.w3.org/2004/02/skos/core#definition> """A series of actions or operations conducing to an end
-In PMD, a process is conducted via process nodes and has a discernable duration as part of a workflow. A process consumes objects and parameters. A process potentially generates new objects and measurements. A process is either a transformative process or a non-transformative process with respect to objects processed via a process node. There are primarily two types of distinguishable processes: manufacture process, analysis process. A process is a series of operations that are subordinate processes."""@en .
-
-
-###  http://material-digital.de/pmdao/tto/ProcessDescription
-<http://material-digital.de/pmdao/tto/ProcessDescription> rdf:type owl:Class ;
-                                                          owl:equivalentClass [ owl:intersectionOf ( <http://material-digital.de/pmdao/tto/Description>
-                                                                                                     [ rdf:type owl:Restriction ;
-                                                                                                       owl:onProperty <http://material-digital.de/pmdao/tto/isCharacteristicOf> ;
-                                                                                                       owl:someValuesFrom <http://material-digital.de/pmdao/tto/Process>
-                                                                                                     ]
-                                                                                                   ) ;
-                                                                                rdf:type owl:Class
-                                                                              ] ;
-                                                          rdfs:subClassOf <http://material-digital.de/pmdao/tto/Description> ;
-                                                          rdfs:label "Process Description"@en ,
-                                                                     "Prozessbeschreibung"@de ;
-                                                          <http://www.w3.org/2004/02/skos/core#definition> "A descriptive text qualifying the nature of a process instance used as an identifier that is not strictly intended to be unique, e.g. \"1050°C30 840°C10/ÖL\"."@en ,
-                                                                                                           "A human readable order of steps. Might include additional information that likes sketches and notes."@en .
-
-
-###  http://material-digital.de/pmdao/tto/ProcessDuration
-<http://material-digital.de/pmdao/tto/ProcessDuration> rdf:type owl:Class ;
-                                                       rdfs:subClassOf <http://material-digital.de/pmdao/tto/ValueObject> ;
-                                                       rdfs:label "Process Duration"@en ,
-                                                                  "Prozessdauer"@de ;
-                                                       <http://www.w3.org/2004/02/skos/core#definition> "A length of an interval of time in which a process is conducted."@en .
-
-
-###  http://material-digital.de/pmdao/tto/ProcessIdentifier
-<http://material-digital.de/pmdao/tto/ProcessIdentifier> rdf:type owl:Class ;
-                                                         owl:equivalentClass [ owl:intersectionOf ( <http://material-digital.de/pmdao/tto/Identifier>
-                                                                                                    [ rdf:type owl:Restriction ;
-                                                                                                      owl:onProperty <http://material-digital.de/pmdao/tto/isCharacteristicOf> ;
-                                                                                                      owl:someValuesFrom <http://material-digital.de/pmdao/tto/Process>
-                                                                                                    ]
-                                                                                                  ) ;
-                                                                               rdf:type owl:Class
-                                                                             ] ;
-                                                         rdfs:subClassOf <http://material-digital.de/pmdao/tto/Identifier> ;
-                                                         rdfs:label "Process Identifier"@en ,
-                                                                    "Prozessidentifikator"@de ;
-                                                         <http://www.w3.org/2004/02/skos/core#definition> "A colloquial, human-generated, descriptive text qualifying the nature of a process instance used as an identifier that is not strictly intended to be unique, e.g. “1050°C30 840°C10/ÖL”."@en ,
-                                                                                                          "Ein umgangssprachlicher, von Menschen erstellter, beschreibender Text, der die Art einer Prozessinstanz qualifiziert, die als Kennung verwendet wird, die nicht unbedingt eindeutig sein muss, z.B. “1050°C30 840°C10/ÖL”."@de .
-
-
-###  http://material-digital.de/pmdao/tto/ProcessingNode
-<http://material-digital.de/pmdao/tto/ProcessingNode> rdf:type owl:Class ;
-                                                      rdfs:subClassOf <http://www.w3.org/ns/prov#Entity> ;
-                                                      rdfs:label "Processing Node"@en ,
-                                                                 "Prozessknoten"@de ;
-                                                      <http://www.w3.org/2004/02/skos/core#definition> "A workflow constituent that hosts tools in the form of software to facilitate, e.g. simulation, prediction, or machine learning."@en .
-
-
-###  http://material-digital.de/pmdao/tto/Project
-<http://material-digital.de/pmdao/tto/Project> rdf:type owl:Class ;
-                                               rdfs:subClassOf <http://www.w3.org/ns/prov#Activity> ;
-                                               rdfs:label "Project"@en ,
-                                                          "Projekt"@de ;
-                                               <http://www.w3.org/2004/02/skos/core#definition> "A series of goal-orientated (intent) activities and interactions to achieve a specific outcome."@en ,
-                                                                                                "Eine Reihe von zielorientierten (absichtlichen) Aktivitäten und Interaktionen, um ein bestimmtes Ergebnis zu erzielen."@de .
-
-
-###  http://material-digital.de/pmdao/tto/ProjectIdentifier
-<http://material-digital.de/pmdao/tto/ProjectIdentifier> rdf:type owl:Class ;
-                                                         owl:equivalentClass [ owl:intersectionOf ( <http://material-digital.de/pmdao/tto/Identifier>
-                                                                                                    [ rdf:type owl:Restriction ;
-                                                                                                      owl:onProperty <http://material-digital.de/pmdao/tto/isCharacteristicOf> ;
-                                                                                                      owl:someValuesFrom <http://material-digital.de/pmdao/tto/Project>
-                                                                                                    ]
-                                                                                                  ) ;
-                                                                               rdf:type owl:Class
-                                                                             ] ;
-                                                         rdfs:subClassOf <http://material-digital.de/pmdao/tto/Identifier> ;
-                                                         rdfs:label "Project Identifier"@en ,
-                                                                    "Projektidentifikator"@de ;
-                                                         <http://www.w3.org/2004/02/skos/core#definition> "A colloquial, human-generated, descriptive text qualifying the nature of a project."@en ,
-                                                                                                          "Ein umgangssprachlicher, von Menschen erstellter, beschreibender Text, der die Art eines Projekts qualifiziert."@de .
-
-
-###  http://material-digital.de/pmdao/tto/ProofStrength
-<http://material-digital.de/pmdao/tto/ProofStrength> rdf:type owl:Class ;
-                                                     rdfs:subClassOf <http://material-digital.de/pmdao/tto/Extension> ;
-                                                     rdfs:label "Dehngrenze"@de ,
-                                                                "Proof Strength"@en ;
-                                                     <http://www.w3.org/2004/02/skos/core#definition> "Spannung, bei der ein bestimmter Dehnungswert gleich einem bestimmten Prozentsatz der Messlänge des Dehnungsmessers ist"@de ,
-                                                                                                      "stress at which the a specific extension value is equal to a specified percentage of the extensometer gauge length"@en .
-
-
-###  http://material-digital.de/pmdao/tto/ProofStrengthPlasticExtension
-<http://material-digital.de/pmdao/tto/ProofStrengthPlasticExtension> rdf:type owl:Class ;
-                                                                     rdfs:subClassOf <http://material-digital.de/pmdao/tto/ProofStrength> ;
-                                                                     <http://material-digital.de/pmdao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en ;
-                                                                     rdfs:label "Dehngrenze bei plastischer Extensometer-Dehnung"@de ,
-                                                                                "Proof Strength Plastic Extension"@en ;
-                                                                     <http://www.w3.org/2004/02/skos/core#definition> """Spannung, bei der die plastische Extensometer-Dehnung einem vorgegebenen Prozentanteil der Extensometer-Messlänge entspricht
-
-Anmerkung: Der Index wird durch den Zahlenwert ergänzt, der den vorgegebenen Zahlenwert der plastischen Extensometer-Dehnung in Prozent angibt, z. B. R_p_0,2."""@de ,
-                                                                                                                      "Symbol: R_p"@en ,
-                                                                                                                      """stress at which the plastic extension is equal to a specified percentage of the extensometer gauge length
-
-Note: A suffix is added to the subscript to indicate the prescribed percentage, e.g. R_p_0.2.
-
-Source: ISO 6892-1:2019"""@en .
-
-
-###  http://material-digital.de/pmdao/tto/ProofStrengthTotalExtension
-<http://material-digital.de/pmdao/tto/ProofStrengthTotalExtension> rdf:type owl:Class ;
-                                                                   owl:equivalentClass [ rdf:type owl:Restriction ;
-                                                                                         owl:onProperty <http://material-digital.de/pmdao/tto/relatesTo> ;
-                                                                                         owl:someValuesFrom <http://material-digital.de/pmdao/tto/PercentageExtension>
-                                                                                       ] ;
-                                                                   rdfs:subClassOf <http://material-digital.de/pmdao/tto/ProofStrength> ;
-                                                                   <http://material-digital.de/pmdao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en ;
-                                                                   rdfs:label "Dehngrenze bei gesamter Extensometer-Dehnung"@de ,
-                                                                              "Proof Strength Total Extension"@en ;
-                                                                   <http://www.w3.org/2004/02/skos/core#definition> """Spannung, bei der die gesamte Extensometer-Dehnung (elastische und plastische Extensometer-Dehnung) einem vorgegebenen Prozentanteil der Extensometer-Messlänge entspricht
-
-Anmerkung: Der Index wird durch den Zahlenwert ergänzt, der den vorgegebenen Zahlenwert der gesamten Extensometer-Dehnung in Prozent angibt, z. B. R_t_0,5."""@de ,
-                                                                                                                    "Symbol: R_t"@en ,
-                                                                                                                    """stress at which total extension (elastic extension plus plastic extension) is equal to a specified percentage of the extensometer gauge length
-
-Note: A suffix is added to the subscript to indicate the prescribed percentage, e.g. R_t_0.5."""@en .
-
-
-###  http://material-digital.de/pmdao/tto/ProvidedIdentifier
-<http://material-digital.de/pmdao/tto/ProvidedIdentifier> rdf:type owl:Class ;
-                                                          rdfs:subClassOf <http://material-digital.de/pmdao/tto/Identifier> ;
-                                                          rdfs:label "Bereitgestellter Identifikator"@de ,
-                                                                     "Provided Identifier"@en ;
-                                                          <http://www.w3.org/2004/02/skos/core#definition> "A colloquial, human-generated desrciptor."@en .
-
-
-###  http://material-digital.de/pmdao/tto/QualifyingNodeAnnotation
-<http://material-digital.de/pmdao/tto/QualifyingNodeAnnotation> rdf:type owl:Class ;
-                                                                rdfs:subClassOf <http://material-digital.de/pmdao/tto/NodeInfo> ;
-                                                                rdfs:label "Qualifizierende Knotenannotation"@de ,
-                                                                           "Qualifying Node Annotation"@en ;
-                                                                <http://www.w3.org/2004/02/skos/core#definition> "Description for Process Node's utility, e.g. \"Rear Vacuum Furnace Oil Quenching\""@en .
-
-
-###  http://material-digital.de/pmdao/tto/Radiological
-<http://material-digital.de/pmdao/tto/Radiological> rdf:type owl:Class ;
-                                                    rdfs:subClassOf <http://material-digital.de/pmdao/tto/MaterialProperty> ;
-                                                    <http://material-digital.de/pmdao/tto/definitionSource> "“Radiological.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/radiological. Accessed 13 Jan. 2023."@en ;
-                                                    rdfs:label "Radiological"@en ,
-                                                               "Radiologisch"@de ;
-                                                    <http://www.w3.org/2004/02/skos/core#definition> "Radiological is relating to radiology. Here specifically to the radiological properties of a material."@en ,
-                                                                                                     "Radiologisch bezieht sich auf die Radiologie. Hier speziell auf die radiologischen Eigenschaften eines Materials."@de .
-
-
-###  http://material-digital.de/pmdao/tto/Radius
-<http://material-digital.de/pmdao/tto/Radius> rdf:type owl:Class ;
-                                              rdfs:subClassOf <http://material-digital.de/pmdao/tto/ValueObject> ;
-                                              <http://material-digital.de/pmdao/tto/definitionSource> "“Radius.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/radius. Accessed 5 Dec. 2022."@en ;
-                                              rdfs:label "Radius"@de ,
-                                                         "Radius"@en ;
-                                              <http://www.w3.org/2004/02/skos/core#definition> "A line segment extending from the center of a circle or sphere to the circumference or bounding surface."@en .
-
-
-###  http://material-digital.de/pmdao/tto/Rectangular
-<http://material-digital.de/pmdao/tto/Rectangular> rdf:type owl:Class ;
-                                                   rdfs:subClassOf <http://material-digital.de/pmdao/tto/Shape> ;
-                                                   <http://material-digital.de/pmdao/tto/definitionSource> "“Rectangular.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/rectangular. Accessed 13 Jan. 2023."@en ;
-                                                   rdfs:label "Rechteckig"@de ,
-                                                              "Rectangular"@en ;
-                                                   <http://www.w3.org/2004/02/skos/core#definition> "Geformt wie ein Rechteck."@de ,
-                                                                                                    "Shaped like a rectangle."@en .
-
-
-###  http://material-digital.de/pmdao/tto/RegionOfInterest
-<http://material-digital.de/pmdao/tto/RegionOfInterest> rdf:type owl:Class ;
-                                                        rdfs:subClassOf <http://material-digital.de/pmdao/tto/Object> ;
-                                                        rdfs:label "Betrachteter Bereich"@de ,
-                                                                   "Region of Interest"@en ;
-                                                        <http://www.w3.org/2004/02/skos/core#definition> "Some region of interest in an image. You might refer to some resource of an annotation ontology."@en .
-
-
-###  http://material-digital.de/pmdao/tto/Regression
-<http://material-digital.de/pmdao/tto/Regression> rdf:type owl:Class ;
-                                                  rdfs:subClassOf <http://material-digital.de/pmdao/tto/Algorithm> ;
-                                                  <http://material-digital.de/pmdao/tto/definitionSource> "“Regression.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/regression. Accessed 24 Nov. 2022."@en ;
-                                                  rdfs:label "Regression"@de ,
-                                                             "Regression"@en ;
-                                                  <http://www.w3.org/2004/02/skos/core#definition> """A functional relationship between two or more correlated variables that is often empirically determined from data and is used especially to predict values of one variable when given values of the others.
-Specifically : a function that yields the mean value of a random variable under the condition that one or more independent variables have specified values."""@en ;
-                                                  <http://www.w3.org/2004/02/skos/core#example> "Regression of y on x is linear"@en .
-
-
-###  http://material-digital.de/pmdao/tto/RelatedProjectIdentifier
-<http://material-digital.de/pmdao/tto/RelatedProjectIdentifier> rdf:type owl:Class ;
-                                                                rdfs:subClassOf <http://material-digital.de/pmdao/tto/Identifier> ;
-                                                                rdfs:label "Identifikation Eines Verbundenen Projektes"@de ,
-                                                                           "Related Project Identifier"@en ;
-                                                                <http://www.w3.org/2004/02/skos/core#definition> "Diese Eigenschaft beschreibt einen benannten Wert, der dazu dient, zwischen Projekten zu unterscheiden, die mit dem betrachteten Projekt in Relation stehen. Zwei in Relation stehende Projekte könnten zum Beispiel ein Messprojekt sein, das Teil eines Projekts mit einem breiteren Betrachtungsbereich ist."@de ,
-                                                                                                                 "This property describes a named value intended to distinguish between projects that are related to the project considered. For instance, two related projects could be a measurement project that is part of project with a broader scope."@en .
-
-
-###  http://material-digital.de/pmdao/tto/Roughness
-<http://material-digital.de/pmdao/tto/Roughness> rdf:type owl:Class ;
-                                                 rdfs:subClassOf <http://material-digital.de/pmdao/tto/ValueObject> ;
-                                                 <http://material-digital.de/pmdao/tto/definitionSource> "http://en.wikipedia.org/wiki/Surface_roughness"@en ;
-                                                 rdfs:label "Oberflächenrauheit"@de ,
-                                                            "Roughness"@en ;
-                                                 <http://www.w3.org/2004/02/skos/core#definition> "Die Oberflächenrauheit, oft abgekürzt als Rauheit, ist eine Komponente zur Beschreibung der Oberflächenbeschaffenheit (Oberflächentextur). Sie wird durch die Abweichungen in der Richtung des Normalenvektors einer realen Oberfläche von ihrer idealen Form quantifiziert. Sind diese Abweichungen groß, ist die Oberfläche rau (große Rauheit), sind sie klein, ist die Oberfläche glatt (geringe Rauheit)."@de ,
-                                                                                                  "Surface roughness, often shortened to roughness, is a component of surface finish (surface texture). It is quantified by the deviations in the direction of the normal vector of a real surface from its ideal form. If these deviations are large, the surface is rough; if they are small, the surface is smooth."@en .
-
-
-###  http://material-digital.de/pmdao/tto/Rp01
-<http://material-digital.de/pmdao/tto/Rp01> rdf:type owl:Class ;
-                                            owl:equivalentClass [ rdf:type owl:Restriction ;
-                                                                  owl:onProperty <http://material-digital.de/pmdao/tto/relatesToExtension> ;
-                                                                  owl:someValuesFrom [ rdf:type owl:Restriction ;
-                                                                                       owl:onProperty <http://material-digital.de/pmdao/tto/hasValue> ;
-                                                                                       owl:hasValue "0.1"^^xsd:float
-                                                                                     ]
-                                                                ] ;
-                                            rdfs:subClassOf <http://material-digital.de/pmdao/tto/ProofStrengthPlasticExtension> ;
-                                            <http://material-digital.de/pmdao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en ;
-                                            rdfs:label "Dehngrenze bei plastischer Extensometer-Dehnung Rp01"@de ,
-                                                       "Proof Strength Plastic Extension Rp01"@en ;
-                                            <http://www.w3.org/2004/02/skos/core#definition> "Spannung bei einer plastischen Extensometer-Dehnung, die 0,1 Prozent der Extensometer-Messlänge entspricht"@de ,
-                                                                                             "Symbol: R_p_0.1"@en ,
-                                                                                             "stress at which the plastic extension is equal to 0.1 percent of the extensometer gauge length"@en .
-
-
-###  http://material-digital.de/pmdao/tto/Rp02
-<http://material-digital.de/pmdao/tto/Rp02> rdf:type owl:Class ;
-                                            owl:equivalentClass [ rdf:type owl:Restriction ;
-                                                                  owl:onProperty <http://material-digital.de/pmdao/tto/relatesToExtension> ;
-                                                                  owl:someValuesFrom [ rdf:type owl:Restriction ;
-                                                                                       owl:onProperty <http://material-digital.de/pmdao/tto/hasValue> ;
-                                                                                       owl:hasValue "0.2"^^xsd:float
-                                                                                     ]
-                                                                ] ;
-                                            rdfs:subClassOf <http://material-digital.de/pmdao/tto/ProofStrengthPlasticExtension> ;
-                                            <http://material-digital.de/pmdao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en ;
-                                            rdfs:label "Dehngrenze bei plastischer Extensometer-Dehnung Rp02"@de ,
-                                                       "Proof Strength Plastic Extension Rp02"@en ;
-                                            <http://www.w3.org/2004/02/skos/core#definition> "Spannung bei einer plastischen Extensometer-Dehnung, die 0,2 Prozent der Extensometer-Messlänge entspricht"@de ,
-                                                                                             "Symbol: R_p_0.2"@en ,
-                                                                                             "stress at which the plastic extension is equal to 0.2 percent of the extensometer gauge length"@en .
-
-
-###  http://material-digital.de/pmdao/tto/Sample
-<http://material-digital.de/pmdao/tto/Sample> rdf:type owl:Class ;
-                                              rdfs:subClassOf <http://material-digital.de/pmdao/tto/EngineeredMaterial> ;
-                                              <http://material-digital.de/pmdao/tto/definitionSource> "ISO 18589-1:2019-11 (international standardization committee: ISO/TC 85/SC 2/WG 17)"@en ;
-                                              rdfs:label "Probe"@de ,
-                                                         "Sample"@en ;
-                                              <http://www.w3.org/2004/02/skos/core#definition> "Portion of material, usually selected from a larger quantity of material, collected and taken away for testing"@en .
-
-
-###  http://material-digital.de/pmdao/tto/SecondaryData
-<http://material-digital.de/pmdao/tto/SecondaryData> rdf:type owl:Class ;
-                                                     rdfs:subClassOf <http://material-digital.de/pmdao/tto/DataScope> ;
-                                                     rdfs:label "Secondary Data"@en ,
-                                                                "Sekundärdaten"@de ;
-                                                     <http://www.w3.org/2004/02/skos/core#definition> "Characteristic values (e.g. test results) determined by equations or algorithms using primary data and metadata for a process"@en .
-
-
-###  http://material-digital.de/pmdao/tto/SemiCrystallineStructure
-<http://material-digital.de/pmdao/tto/SemiCrystallineStructure> rdf:type owl:Class ;
-                                                                rdfs:subClassOf <http://material-digital.de/pmdao/tto/MaterialStructure> ;
-                                                                rdfs:label "Semi Crystalline Structure"@en ,
-                                                                           "Semikristalline Struktur"@de ;
-                                                                <http://www.w3.org/2004/02/skos/core#definition> "Feststoffe, die eine teilkristalline Struktur aufweisen, enthalten sowohl kristalline als auch amorphe Bereiche (Domänen). Kristalline Stoffe, die keine Einkristalle, sondern Polykristalle sind, werden nicht als teilkristallin bezeichnet, auch wenn sich zwischen den Kristalliten ein dünner amorpher Film befindet."@de ,
-                                                                                                                 "Solid materials exhibiting a semi-crystalline structure contain both crystalline and amorphous sections (domains). Crystalline substances that are polycrystals rather than single crystals are not designated as semicrystalline, even if there is a thin amorphous film between the crystallites."@en .
-
-
-###  http://material-digital.de/pmdao/tto/SequenceNumber
-<http://material-digital.de/pmdao/tto/SequenceNumber> rdf:type owl:Class ;
-                                                      rdfs:subClassOf <http://material-digital.de/pmdao/tto/Identifier> ;
-                                                      rdfs:label "Sequence Number"@en ,
-                                                                 "Sequenznummer"@de ;
-                                                      <http://www.w3.org/2004/02/skos/core#definition> "Strict monotonically increasing integer that indicates the position in an ordered list."@en .
-
-
-###  http://material-digital.de/pmdao/tto/SetPoint
-<http://material-digital.de/pmdao/tto/SetPoint> rdf:type owl:Class ;
-                                                rdfs:subClassOf <http://material-digital.de/pmdao/tto/ValueScope> ;
-                                                <http://material-digital.de/pmdao/tto/definitionSource> "http://de.wikipedia.org/wiki/Sollwert"@de ,
-                                                                                                        "http://en.wikipedia.org/wiki/Setpoint_(control_system)"@en ;
-                                                rdfs:label "Set Point"@en ,
-                                                           "Sollwert"@de ;
-                                                <http://www.w3.org/2004/02/skos/core#definition> "In cybernetics and control theory, a setpoint (SP;[1] also set point) is the desired or target value for an essential variable, or process value (PV) of a control system."@en ,
-                                                                                                 "Sollwert bezeichnet allgemein den angestrebten Wert eines quantitativen Merkmales eines Systems, von dem der tatsächliche Istwert so wenig wie möglich abweichen soll. Der Sollwert wird von einem anderen System (z. B. Technik, Mensch) vorgegeben."@de .
-
-
-###  http://material-digital.de/pmdao/tto/Shape
-<http://material-digital.de/pmdao/tto/Shape> rdf:type owl:Class ;
-                                             rdfs:subClassOf <http://material-digital.de/pmdao/tto/ValueObject> ;
-                                             <http://material-digital.de/pmdao/tto/definitionSource> "“Shape.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/shape. Accessed 13 Jan. 2023."@en ;
-                                             rdfs:label "Form"@de ,
-                                                        "Shape"@en ;
-                                             <http://www.w3.org/2004/02/skos/core#definition> "Das sichtbare Ausstattungsmerkmal (räumliche Form oder Kontur) eines bestimmten Objektes oder einer Art von Objekt."@de ,
-                                                                                              "The visible makeup characteristic (spatial form or contour) of a particular item or kind of item."@en .
-
-
-###  http://material-digital.de/pmdao/tto/Slide
-<http://material-digital.de/pmdao/tto/Slide> rdf:type owl:Class ;
-                                             rdfs:subClassOf <http://material-digital.de/pmdao/tto/ProcessingNode> ;
-                                             rdfs:label "Schlitten"@de ,
-                                                        "Slide"@en ;
-                                             <http://www.w3.org/2004/02/skos/core#definition> "A moving piece that is guided by a part along its path, providing the mount for objects."@en .
-
-
-###  http://material-digital.de/pmdao/tto/SlopeOfTheElasticPart
-<http://material-digital.de/pmdao/tto/SlopeOfTheElasticPart> rdf:type owl:Class ;
-                                                             rdfs:subClassOf <http://material-digital.de/pmdao/tto/ValueObject> ;
-                                                             <http://material-digital.de/pmdao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en ;
-                                                             rdfs:label "Slope Of The Elastic Part"@en ,
-                                                                        "Steigung des elastischen Bereichs"@de ;
-                                                             <http://www.w3.org/2004/02/skos/core#definition> "Diese Eigenschaft beschreibt den Wert der Steigung des ersten linear ansteigenden Teils (\"elastischer Teil\") in der bei einem Zugversuch erhaltenen Spannungs-Dehnungs-Kurve. Im elastischen Teil der Spannungs-Dehnungs-Kurve muss der Wert der Steigung nicht unbedingt dem Elastizitätsmodul entsprechen. Dieser Wert kann mit dem Wert des Elastizitätsmoduls (nur) sehr gut übereinstimmen, wenn optimale Bedingungen herrschten."@de ,
-                                                                                                              "This property describes the value of the slope of the first linear increasing part (‘elastic part’) in the stress-percentage extension curve obtained during a tensile test. In the elastic part of the stress‐percentage extension curve, the value of the slope may not necessarily represent the modulus of elasticity. This value may closely agree with the value of the modulus of elasticity if optimal conditions were used."@en .
-
-
-###  http://material-digital.de/pmdao/tto/Specimen
-<http://material-digital.de/pmdao/tto/Specimen> rdf:type owl:Class ;
-                                                rdfs:subClassOf <http://material-digital.de/pmdao/tto/Sample> ;
-                                                owl:disjointWith <http://material-digital.de/pmdao/tto/TestPiece> ;
-                                                rdfs:label "Prüfling"@de ,
-                                                           "Specimen"@en ;
-                                                <http://www.w3.org/2004/02/skos/core#definition> "An object designed for a specific analysis." .
-
-
-###  http://material-digital.de/pmdao/tto/SpecimenName
-<http://material-digital.de/pmdao/tto/SpecimenName> rdf:type owl:Class ;
-                                                    owl:equivalentClass [ owl:intersectionOf ( <http://material-digital.de/pmdao/tto/Identifier>
-                                                                                               [ rdf:type owl:Restriction ;
-                                                                                                 owl:onProperty <http://material-digital.de/pmdao/tto/isCharacteristicOf> ;
-                                                                                                 owl:someValuesFrom <http://material-digital.de/pmdao/tto/Specimen>
-                                                                                               ]
-                                                                                             ) ;
-                                                                          rdf:type owl:Class
-                                                                        ] ;
-                                                    rdfs:subClassOf <http://material-digital.de/pmdao/tto/Identifier> ;
-                                                    rdfs:label "Prüfstück Name"@de ,
-                                                               "Specimen Name"@en ;
-                                                    <http://www.w3.org/2004/02/skos/core#definition> "Diese Eigenschaft beschreibt die Bezeichnung eines Prüfstücks, die in der Regel von Menschen als von Menschen lesbarer Identifikator vergeben wird."@de ,
-                                                                                                     "This property describes the designation of a specimen, usually given as human-readable identifier by humans."@de .
-
-
-###  http://material-digital.de/pmdao/tto/Squared
-<http://material-digital.de/pmdao/tto/Squared> rdf:type owl:Class ;
-                                               rdfs:subClassOf <http://material-digital.de/pmdao/tto/Shape> ;
-                                               <http://material-digital.de/pmdao/tto/definitionSource> "“Square.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/square. Accessed 13 Jan. 2023."@en ;
-                                               rdfs:label "Quadratisch"@de ,
-                                                          "Squared"@en ;
-                                               <http://www.w3.org/2004/02/skos/core#definition> "Geformt mit vier gleichen Seiten und vier rechten Winkeln."@de ,
-                                                                                                "Having four equal sides and four right angles."@en .
-
-
-###  http://material-digital.de/pmdao/tto/StartTime
-<http://material-digital.de/pmdao/tto/StartTime> rdf:type owl:Class ;
-                                                 rdfs:subClassOf <http://material-digital.de/pmdao/tto/Time> ;
-                                                 rdfs:label "Start Time"@en ,
-                                                            "Startzeit"@de ;
-                                                 <http://www.w3.org/2004/02/skos/core#definition> "The date and time when the plan/recipe is supposed to be executed."@en .
-
-
-###  http://material-digital.de/pmdao/tto/Stiffness
-<http://material-digital.de/pmdao/tto/Stiffness> rdf:type owl:Class ;
-                                                 rdfs:subClassOf <http://material-digital.de/pmdao/tto/ValueObject> ;
-                                                 rdfs:label "Steifigkeit"@de ,
-                                                            "Stiffness"@en ;
-                                                 <http://www.w3.org/2004/02/skos/core#definition> "Die Steifigkeit ist das Maß, bis zu dem ein Objekt einer Verformung als Reaktion auf eine einwirkende Kraft widersteht."@de ,
-                                                                                                  "Stiffness is the extent to which an object resists deformation in response to an applied force."@en .
-
-
-###  http://material-digital.de/pmdao/tto/StrainRate
-<http://material-digital.de/pmdao/tto/StrainRate> rdf:type owl:Class ;
-                                                  rdfs:subClassOf <http://material-digital.de/pmdao/tto/TestingRate> ;
-                                                  <http://material-digital.de/pmdao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en ;
-                                                  rdfs:label "Dehngeschwindigkeit"@de ,
-                                                             "Strain Rate"@en ;
-                                                  <http://www.w3.org/2004/02/skos/core#definition> "Symbol: e^._L_e"@en ,
-                                                                                                   "Zunahme der mit einem Extensometer in der Extensometer-Messlänge gemessenen Dehnung je Zeiteinheit"@de ,
-                                                                                                   "increase of strain, measured with an extensometer, in extensometer gauge length, per time"@en .
-
-
-###  http://material-digital.de/pmdao/tto/Stress
-<http://material-digital.de/pmdao/tto/Stress> rdf:type owl:Class ;
-                                              owl:equivalentClass [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
-                                                                                           owl:onProperty <http://material-digital.de/pmdao/tto/relatesTo> ;
-                                                                                           owl:someValuesFrom <http://material-digital.de/pmdao/tto/Area>
-                                                                                         ]
-                                                                                         [ rdf:type owl:Restriction ;
-                                                                                           owl:onProperty <http://material-digital.de/pmdao/tto/relatesTo> ;
-                                                                                           owl:someValuesFrom <http://material-digital.de/pmdao/tto/Force>
-                                                                                         ]
-                                                                                       ) ;
-                                                                    rdf:type owl:Class
-                                                                  ] ;
-                                              rdfs:subClassOf <http://material-digital.de/pmdao/tto/ValueObject> ;
-                                              <http://material-digital.de/pmdao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en ;
-                                              rdfs:label "Spannung"@de ,
-                                                         "Stress"@en ;
-                                              <http://www.w3.org/2004/02/skos/core#definition> """At any moment during the test, force divided by the original cross-sectional area, S_o, of the test piece
-
-Note: Here, all references to stress are to engineering stress."""@en ,
-                                                                                               """Dimensional Analysis: 
-ML*-1T*-2"""@en ,
-                                                                                               """Kraft zu einem beliebigen Zeitpunkt während des Versuchs dividiert durch den Anfangsquerschnitt (S_o) der Probe
-
-Anmerkung: Mit dem Begriff Spannung ist hier die technische Spannung ('Ingenieur-Spannung') gemeint."""@de ,
-                                                                                               "Symbol: R"@en ,
-                                                                                               "Units: Pa (SI), psi"@en .
-
-
-###  http://material-digital.de/pmdao/tto/StressRate
-<http://material-digital.de/pmdao/tto/StressRate> rdf:type owl:Class ;
-                                                  rdfs:subClassOf <http://material-digital.de/pmdao/tto/TestingRate> ;
-                                                  <http://material-digital.de/pmdao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en ;
-                                                  rdfs:label "Spannungsgeschwindigkeit"@de ,
-                                                             "Stress Rate"@en ;
-                                                  <http://www.w3.org/2004/02/skos/core#definition> "Symbol: R"@en ,
-                                                                                                   """Zunahme der Spannung je Zeiteinheit
-
-Anmerkung: Die Spannungsgeschwindigkeit wird nur im elastischen Bereich des Versuchs verwendet."""@de ,
-                                                                                                   """increase of stress per time
-
-Note: Stress rate is only used in the elastic part of the test."""@en .
-
-
-###  http://material-digital.de/pmdao/tto/TemperatueMeasuringDevice
-<http://material-digital.de/pmdao/tto/TemperatueMeasuringDevice> rdf:type owl:Class ;
-                                                                 rdfs:subClassOf <http://material-digital.de/pmdao/tto/MeasuringDevice> ;
-                                                                 rdfs:label "Temperatue Measuring Device"@en ,
-                                                                            "Temperaturmesswerkzeug"@de ;
-                                                                 <http://www.w3.org/2004/02/skos/core#definition> "Diese Entität beschreibt allgemein jedes Werkzeug, das zur Messung der Temperatur eines materiellen Objekts oder der Umgebung verwendet wird, z. B. ein Thermoelement und Thermometer."@de ,
-                                                                                                                  "This entity generically describes any tool that is used for the measurement of the temperature of a tangible object or the environment, e.g., a thermocouple and thermometers."@en .
-
-
-###  http://material-digital.de/pmdao/tto/Temperature
-<http://material-digital.de/pmdao/tto/Temperature> rdf:type owl:Class ;
-                                                   rdfs:subClassOf <http://material-digital.de/pmdao/tto/ValueObject> ;
-                                                   <http://material-digital.de/pmdao/tto/definitionSource> "“Temperature.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/temperature. Accessed 25 Nov. 2022."@en ;
-                                                   rdfs:label "Temperatur"@de ,
-                                                              "Temperature"@en ;
-                                                   <http://www.w3.org/2004/02/skos/core#definition> "The degree of hotness or coldness measured on a definite scale."@en .
-
-
-###  http://material-digital.de/pmdao/tto/TemperatureChangeDevice
-<http://material-digital.de/pmdao/tto/TemperatureChangeDevice> rdf:type owl:Class ;
-                                                               rdfs:subClassOf <http://material-digital.de/pmdao/tto/TemperatueMeasuringDevice> ;
-                                                               rdfs:label "Temperature Change Device"@en ,
-                                                                          "Temperaturänderungswerkzeug"@de ;
-                                                               <http://www.w3.org/2004/02/skos/core#definition> "Diese Entität beschreibt allgemein jedes Werkzeug, das zur Änderung und Einstellung der Temperatur eines materiellen Objekts oder der Umgebung verwendet wird, z. B. einen Ofen und Kühlmittel."@de ,
-                                                                                                                "This entity generically describes any tool that is used for the alteration and adjustment of the temperature of a tangible object or the environment, e.g., a furnace and cooling media."@en .
-
-
-###  http://material-digital.de/pmdao/tto/TemperatureChangingProcess
-<http://material-digital.de/pmdao/tto/TemperatureChangingProcess> rdf:type owl:Class ;
-                                                                  rdfs:subClassOf <http://material-digital.de/pmdao/tto/ConditioningProcess> ;
-                                                                  rdfs:label "Temperature Changing Process"@en ,
-                                                                             "Temperaturänderungsprozess"@de ;
-                                                                  <http://www.w3.org/2004/02/skos/core#definition> "This properpy is used to describe a process which is run to increase or decrease the temperature of an object or a space. Usually, this involves heating or cooling devices such as furnaces or cooling media."@en .
-
-
-###  http://material-digital.de/pmdao/tto/TensileStrength
-<http://material-digital.de/pmdao/tto/TensileStrength> rdf:type owl:Class ;
-                                                       owl:equivalentClass [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
-                                                                                                    owl:onProperty <http://material-digital.de/pmdao/tto/relatesTo> ;
-                                                                                                    owl:someValuesFrom <http://material-digital.de/pmdao/tto/MaximumForce>
-                                                                                                  ]
-                                                                                                  [ rdf:type owl:Restriction ;
-                                                                                                    owl:onProperty <http://material-digital.de/pmdao/tto/relatesTo> ;
-                                                                                                    owl:someValuesFrom <http://material-digital.de/pmdao/tto/Stress>
-                                                                                                  ]
-                                                                                                ) ;
-                                                                             rdf:type owl:Class
-                                                                           ] ;
-                                                       rdfs:subClassOf <http://material-digital.de/pmdao/tto/ValueObject> ;
-                                                       <http://material-digital.de/pmdao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en ;
-                                                       rdfs:label "Tensile Strength"@en ,
-                                                                  "Zugfestigkeit"@de ;
-                                                       <http://www.w3.org/2004/02/skos/core#definition> "Spannung, die der Höchstkraft entspricht"@de ,
-                                                                                                        "Symbol: R_m"@en ,
-                                                                                                        "stress corresponding to the maximum force"@en .
-
-
-###  http://material-digital.de/pmdao/tto/TensileTest
-<http://material-digital.de/pmdao/tto/TensileTest> rdf:type owl:Class ;
-                                                   owl:equivalentClass [ rdf:type owl:Restriction ;
-                                                                         owl:onProperty <http://material-digital.de/pmdao/tto/hasParticipant> ;
-                                                                         owl:someValuesFrom <http://material-digital.de/pmdao/tto/TensileTestingMachine>
-                                                                       ] ,
-                                                                       [ rdf:type owl:Restriction ;
-                                                                         owl:onProperty <http://material-digital.de/pmdao/tto/hasParticipant> ;
-                                                                         owl:someValuesFrom <http://material-digital.de/pmdao/tto/TestPiece>
-                                                                       ] ;
-                                                   rdfs:subClassOf <http://material-digital.de/pmdao/tto/MechanicalTestingProcess> ;
-                                                   <http://material-digital.de/pmdao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en ;
-                                                   rdfs:label "Tensile Test"@en ,
-                                                              "Zugversuch"@de ;
-                                                   <http://www.w3.org/2004/02/skos/core#definition> "Tensile tests (tension tests) on materials provide information on their strength, ductility as well as other characteristic values under uniaxial tensile stress."@en ,
-                                                                                                    "The tensile test involves straining a test piece by tensile force, generally to fracture, for the determination of one or more mechanical properties specified by the semantically related and defined terms."@en .
-
-
-###  http://material-digital.de/pmdao/tto/TensileTestNode
-<http://material-digital.de/pmdao/tto/TensileTestNode> rdf:type owl:Class ;
-                                                       rdfs:subClassOf <http://material-digital.de/pmdao/tto/ProcessingNode> ;
-                                                       rdfs:label "Tensile Test Node"@en ,
-                                                                  "Zugversuchsprozessknoten"@de ;
-                                                       <http://www.w3.org/2004/02/skos/core#definition> "Diese Entität beschreibt einen Workflow-Bestandteil, der Werkzeuge und Geräte beinhaltet, die für die Durchführung eines Zugversuchs verwendet werden, z. B. eine Zugprüfmaschine."@de ,
-                                                                                                        "This entity describes a workflow constituent that hosts tools and equipment that is used for the performance of a tensile test, e.g., a tensile test machine."@en .
-
-
-###  http://material-digital.de/pmdao/tto/TensileTestingMachine
-<http://material-digital.de/pmdao/tto/TensileTestingMachine> rdf:type owl:Class ;
-                                                             rdfs:subClassOf <http://material-digital.de/pmdao/tto/TensileTestNode> ,
-                                                                             <http://material-digital.de/pmdao/tto/TestingMachine> ;
-                                                             <http://material-digital.de/pmdao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en ;
-                                                             rdfs:label "Tensile Testing Machine"@en ,
-                                                                        "Zugprüfmaschine"@de ;
-                                                             <http://www.w3.org/2004/02/skos/core#definition> "Maschine zur Durchführung eines Zugversuches; die Regelung und Überwachung des Versuches, die Messungen und die Datenverarbeitung werden üblicherweise mithilfe eines Computers durchgeführt."@de ,
-                                                                                                              "machine to conduct a tensile test; the control and monitoring of the test, the measurements, and the data processing are usually undertaken by computer"@en .
-
-
-###  http://material-digital.de/pmdao/tto/TestPiece
-<http://material-digital.de/pmdao/tto/TestPiece> rdf:type owl:Class ;
-                                                 rdfs:subClassOf <http://material-digital.de/pmdao/tto/Sample> ;
-                                                 <http://material-digital.de/pmdao/tto/definitionSource> "EN 10021:2006-12 (European standardization committee: CEN/TC 459/SC 12/WG 4)"@en ;
-                                                 rdfs:label "Prüfkörper"@de ,
-                                                            "Test Piece"@en ;
-                                                 <http://www.w3.org/2004/02/skos/core#definition> "Part of a sample with specified dimensions, machined or un-machined, brought to a required condition for submission to a given test."@en ,
-                                                                                                  "Teil einer Probe mit bestimmten Dimensionen, bearbeitet oder unbearbeitet, der in einen erforderlichen Zustand gebracht wird, um einer bestimmten Prüfung unterzogen zu werden."@de .
-
-
-###  http://material-digital.de/pmdao/tto/TestPieceClassification
-<http://material-digital.de/pmdao/tto/TestPieceClassification> rdf:type owl:Class ;
-                                                               rdfs:subClassOf <http://material-digital.de/pmdao/tto/TestPieceInfo> ;
-                                                               rdfs:label "Prüfkörperklassifizierung"@de ,
-                                                                          "Test Piece Classification"@en ;
-                                                               <http://www.w3.org/2004/02/skos/core#definition> "Diese Eigenschaft wird verwendet, um Informationen über einen Prüfkörper bezüglich seiner Einordnung gemäß entsprechender Normen zu liefern."@de ,
-                                                                                                                "This property is used to provide information on a test piece concerning its graduation in accordance with corresponding standards."@en .
-
-
-###  http://material-digital.de/pmdao/tto/TestPieceInfo
-<http://material-digital.de/pmdao/tto/TestPieceInfo> rdf:type owl:Class ;
-                                                     rdfs:subClassOf <http://material-digital.de/pmdao/tto/ValueObject> ;
-                                                     rdfs:label "Prüfkörperinformationen"@de ,
-                                                                "Test Piece Info"@en ;
-                                                     <http://www.w3.org/2004/02/skos/core#definition> "Diese Eigenschaft wird verwendet, um Informationen über einen Prüfkörper zu liefern, wie z. B. seine geometrische Form, seine Klassifizierung und andere Parameter, einschließlich von Spezifikationen und Nennwerte. Die Informationen werden in Bezug auf die entsprechenden Normen bereitgestellt."@de ,
-                                                                                                      "This property is used to provide information on a test piece such as its geometric shape, classification, and other parameters, including specifications and nominal values. The information is provided with respect to corresponding standards."@en .
-
-
-###  http://material-digital.de/pmdao/tto/TestPieceName
-<http://material-digital.de/pmdao/tto/TestPieceName> rdf:type owl:Class ;
-                                                     owl:equivalentClass [ owl:intersectionOf ( <http://material-digital.de/pmdao/tto/Identifier>
-                                                                                                [ rdf:type owl:Restriction ;
-                                                                                                  owl:onProperty <http://material-digital.de/pmdao/tto/isCharacteristicOf> ;
-                                                                                                  owl:someValuesFrom <http://material-digital.de/pmdao/tto/TestPiece>
-                                                                                                ]
-                                                                                              ) ;
-                                                                           rdf:type owl:Class
-                                                                         ] ;
-                                                     rdfs:subClassOf <http://material-digital.de/pmdao/tto/Identifier> ;
-                                                     rdfs:label "Prüfkörpername"@de ,
-                                                                "Test Piece Name"@en ;
-                                                     <http://www.w3.org/2004/02/skos/core#definition> "Diese Eigenschaft beschreibt die Bezeichnung eines Prüfkörpers, die in der Regel als menschenlesbarer Identifikator von Menschen vergeben wird."@de ,
-                                                                                                      "This property describes the designation of a test piece, usually given as human-readable identifier by humans."@en .
-
-
-###  http://material-digital.de/pmdao/tto/TestingMachine
-<http://material-digital.de/pmdao/tto/TestingMachine> rdf:type owl:Class ;
-                                                      rdfs:subClassOf <http://material-digital.de/pmdao/tto/ProcessingNode> ;
-                                                      rdfs:label "Prüfmaschine"@de ,
-                                                                 "Testing Machine" ;
-                                                      <http://www.w3.org/2004/02/skos/core#definition> "Diese Entität beschreibt einen Prozessknoten, der für die Durchführung eines bestimmten Tests verwendet wird. Eine Prüfmaschine kann technisch komplex sein und aus mehreren Teilen bestehen."@de ,
-                                                                                                       "This entity describes a processing node that is used to perform a defined test. A testing machine may be technically complex and contain several parts."@en .
-
-
-###  http://material-digital.de/pmdao/tto/TestingRate
-<http://material-digital.de/pmdao/tto/TestingRate> rdf:type owl:Class ;
-                                                   rdfs:subClassOf <http://material-digital.de/pmdao/tto/ValueObject> ;
-                                                   <http://material-digital.de/pmdao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en ;
-                                                   rdfs:label "Prüfgeschwindigkeit"@de ,
-                                                              "Testing Rate"@en ;
-                                                   <http://www.w3.org/2004/02/skos/core#definition> "rate (resp. rates) used during the test"@en ,
-                                                                                                    "während des Versuchs verwendete Geschwindigkeit(en)"@de .
-
-
-###  http://material-digital.de/pmdao/tto/Thermal
-<http://material-digital.de/pmdao/tto/Thermal> rdf:type owl:Class ;
-                                               rdfs:subClassOf <http://material-digital.de/pmdao/tto/MaterialProperty> ;
-                                               <http://material-digital.de/pmdao/tto/definitionSource> "“Thermal.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/thermal. Accessed 13 Jan. 2023."@en ;
-                                               rdfs:label "Thermal"@en ,
-                                                          "Thermisch"@de ;
-                                               <http://www.w3.org/2004/02/skos/core#definition> "Thermal is relating to, or caused by heat. Here specifically to the thermal properties of a material."@en ,
-                                                                                                "Thermisch bedeutet in Bezug auf oder verursacht durch Wärme. Hier speziell auf die thermischen Eigenschaften eines Materials."@de .
-
-
-###  http://material-digital.de/pmdao/tto/Thermocouple
-<http://material-digital.de/pmdao/tto/Thermocouple> rdf:type owl:Class ;
-                                                    rdfs:subClassOf <http://material-digital.de/pmdao/tto/MeasuringDevice> ;
-                                                    <http://material-digital.de/pmdao/tto/definitionSource> "“Thermocouple.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/thermocouple. Accessed 13 Jan. 2023."@en ;
-                                                    rdfs:label "Thermocouple"@en ,
-                                                               "Thermoelement"@de ;
-                                                    <http://www.w3.org/2004/02/skos/core#definition> "A device for measuring temperature in which a pair of wires of dissimilar metals (such as copper and iron) are joined and the free ends of the wires are connected to an instrument (such as a voltmeter) that measures the difference in potential created at the junction of the two metals."@en ,
-                                                                                                     "Ein Gerät zur Temperaturmessung, bei dem ein Paar Drähte aus unterschiedlichen Metallen (z. B. Kupfer und Eisen) verbunden und die freien Enden der Drähte mit einem Instrument (z. B. einem Voltmeter) verbunden werden, das die an der Verbindungsstelle erzeugte der beiden Metalle Potentialdifferenz misst ."@de .
-
-
-###  http://material-digital.de/pmdao/tto/ThicknessAfterFracture
-<http://material-digital.de/pmdao/tto/ThicknessAfterFracture> rdf:type owl:Class ;
-                                                              rdfs:subClassOf <http://material-digital.de/pmdao/tto/Length> ;
-                                                              rdfs:label "End-Dicke"@de ,
-                                                                         "Thickness After Fracture"@en ;
-                                                              <http://www.w3.org/2004/02/skos/core#definition> "Diese Eigenschaft beschreibt die gemessene Dimension in einer Richtung eines Prüfstücks, wie sie vor der Prüfung gemessen wurde."@de ,
-                                                                                                               "This property describes the measured dimension in one direction of a test piece, as measured after the test."@en .
-
-
-###  http://material-digital.de/pmdao/tto/Time
-<http://material-digital.de/pmdao/tto/Time> rdf:type owl:Class ;
-                                            rdfs:subClassOf <http://material-digital.de/pmdao/tto/ValueObject> ;
-                                            <http://material-digital.de/pmdao/tto/definitionSource> "“Time.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/time. Accessed 25 Nov. 2022."@en ;
-                                            rdfs:label "Time"@en ,
-                                                       "Zeit"@de ;
-                                            <http://www.w3.org/2004/02/skos/core#definition> "A nonspatial continuum that is measured in terms of events which succeed one another from past through present to future."@en .
-
-
-###  http://material-digital.de/pmdao/tto/TransformativeAnalysisProcess
-<http://material-digital.de/pmdao/tto/TransformativeAnalysisProcess> rdf:type owl:Class ;
-                                                                     rdfs:subClassOf <http://material-digital.de/pmdao/tto/AnalysingProcess> ;
-                                                                     rdfs:label "Transformative Analysis Process"@en ,
-                                                                                "Transformativer Analyseprozess"@de ;
-                                                                     <http://www.w3.org/2004/02/skos/core#definition> "An analysis process that is also a transformative process"@en .
-
-
-###  http://material-digital.de/pmdao/tto/TypeGaugeLengthMarks
-<http://material-digital.de/pmdao/tto/TypeGaugeLengthMarks> rdf:type owl:Class ;
-                                                            rdfs:subClassOf <http://material-digital.de/pmdao/tto/TestPieceInfo> ;
-                                                            rdfs:label "Typ Der Messlängenmarkierungen"@de ,
-                                                                       "Type Gauge Length Marks"@en ;
-                                                            <http://www.w3.org/2004/02/skos/core#definition> "Diese Eigenschaft wird verwendet, um die sichtbaren Markierungen zu beschreiben, die in der Regel während eines Zugversuchs zur Messung der Dehnung an den Prüfkörpern angebracht werden."@de ,
-                                                                                                             "This property is used to describe the visible markers usually attached to test pieces during a tensile test for elongation / extension measurements."@en .
-
-
-###  http://material-digital.de/pmdao/tto/UpperYieldStrength
-<http://material-digital.de/pmdao/tto/UpperYieldStrength> rdf:type owl:Class ;
-                                                          owl:equivalentClass [ rdf:type owl:Restriction ;
-                                                                                owl:onProperty <http://material-digital.de/pmdao/tto/relatesTo> ;
-                                                                                owl:someValuesFrom <http://material-digital.de/pmdao/tto/Stress>
-                                                                              ] ;
-                                                          rdfs:subClassOf <http://material-digital.de/pmdao/tto/YieldStrength> ;
-                                                          <http://material-digital.de/pmdao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en ;
-                                                          rdfs:label "Obere Streckgrenze"@de ,
-                                                                     "Upper Yield Strength"@en ;
-                                                          <http://www.w3.org/2004/02/skos/core#definition> "Symbol: R_eH"@en ,
-                                                                                                           "höchste Spannung, bevor der erste Kraftabfall auftritt"@de ,
-                                                                                                           "maximum value of stress prior to the first decrease in force"@en .
-
-
-###  http://material-digital.de/pmdao/tto/ValueObject
-<http://material-digital.de/pmdao/tto/ValueObject> rdf:type owl:Class ;
-                                                   owl:equivalentClass [ rdf:type owl:Class ;
-                                                                         owl:unionOf ( <http://material-digital.de/pmdao/tto/Metadata>
-                                                                                       [ owl:intersectionOf ( [ rdf:type owl:Class ;
-                                                                                                                owl:unionOf ( <http://material-digital.de/pmdao/tto/Measurement>
-                                                                                                                              <http://material-digital.de/pmdao/tto/SetPoint>
-                                                                                                                            )
-                                                                                                              ]
-                                                                                                              [ rdf:type owl:Class ;
-                                                                                                                owl:unionOf ( <http://material-digital.de/pmdao/tto/PrimaryData>
-                                                                                                                              <http://material-digital.de/pmdao/tto/SecondaryData>
-                                                                                                                            )
-                                                                                                              ]
-                                                                                                            ) ;
-                                                                                         rdf:type owl:Class
-                                                                                       ]
-                                                                                     )
-                                                                       ] ;
-                                                   rdfs:subClassOf <http://www.w3.org/ns/prov#Entity> ;
-                                                   rdfs:label "Value Object"@en ,
-                                                              "Wertobjekt"@de ;
-                                                   <http://www.w3.org/2004/02/skos/core#definition> """A :ValueObject is a simple entity which represents a specific value. This value can be a numerical, textual, or a more complex data structure. If a literal value is to be specified, the :hasValue datatype property has to be used. In cases where the value is represented by a resource (e.g. URI), the :hasResource object property has to be used.
-
-A value object, respectively its value, is always associated with an entity of type :Process, :ProcessNode, or :Object (e.g. :Specimen). The value is meant to be a charactaristic of the associated entity. To express this association it is indended to use the :hasParticipant object property.
-
-A value object might also refer to a certain unit. The :hasUnit property might be used (e.g. with QUDT ontology).
-
-Instances of a value object might be specified as a specific Parameter, namely a SetPoint (nominal value), or Measurement. With :Setpoint the intend is to express, that the value is meant to be some preset, setting or nominal value. :Measurement expresses, that the value has been measured or determined somehow (see example).
-
-Instances of a value object might also be specified in a specific DataScope (:Metadata, :PrimaryData, :SecondaryData)."""@en ;
-                                                   <http://www.w3.org/2004/02/skos/core#example> """- the length of a specimen
-- the model number of a machine
-- a person involved in a process
-- a force on an object"""@en ,
-                                                                                                 """:Length rdfs:subClass :ValueObject .
-ex:vo1 a :Length .
-ex:vo1 a :Measurement .
-ex:vo1 a :PrimaryData .
-ex:vo1 :hasUnit qudt:MilliM . 
-ex:vo1 :hasValue \"123.45\"
-ex:spec1 a :Specimen .
-ex:spec1 :hasCharacteristic ex:vo1 ."""@en ,
-                                                                                                 "The length of a specimen, which has been measured as primary data. Its actual value is 123.45 millimeters."@en .
-
-
-###  http://material-digital.de/pmdao/tto/ValueScope
-<http://material-digital.de/pmdao/tto/ValueScope> rdf:type owl:Class ;
-                                                  rdfs:subClassOf <http://www.w3.org/ns/prov#Entity> ;
-                                                  <http://material-digital.de/pmdao/tto/definitionSource> "“Parameter.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/parameter. Accessed 25 Nov. 2022."@en ;
-                                                  rdfs:label "Value Scope"@en ,
-                                                             "Wertekategorie"@de ;
-                                                  <http://www.w3.org/2004/02/skos/core#definition> "Any of a set of physical properties whose values determine the characteristics or behavior of something."@en .
-
-
-###  http://material-digital.de/pmdao/tto/VanderwaalsBond
-<http://material-digital.de/pmdao/tto/VanderwaalsBond> rdf:type owl:Class ;
-                                                       rdfs:subClassOf <http://material-digital.de/pmdao/tto/BondingType> ;
-                                                       <http://material-digital.de/pmdao/tto/definitionSource> "“Van der Waals forces.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/van%20der%20Waals%20forces. Accessed 13 Jan. 2023."@en ;
-                                                       rdfs:label "Van der Waals Bindung"@de ,
-                                                                  "Vanderwaals Bond"@en ;
-                                                       <http://www.w3.org/2004/02/skos/core#definition> "Die Van-der-Waals-Bindung ist durch die relativ schwachen Anziehungskräfte gegeben, die auf neutrale Atome und Moleküle wirken und die aufgrund der elektrischen Polarisierung entstehen, die in jedem der Teilchen durch die Anwesenheit anderer Teilchen induziert wird."@de ,
-                                                                                                        "Van der Waals bond is given by the relatively weak attractive forces that act on neutral atoms and molecules and that arise because of the electric polarization induced in each of the particles by the presence of other particles."@en .
-
-
-###  http://material-digital.de/pmdao/tto/Weight
-<http://material-digital.de/pmdao/tto/Weight> rdf:type owl:Class ;
-                                              rdfs:subClassOf <http://material-digital.de/pmdao/tto/ValueObject> ;
-                                              <http://material-digital.de/pmdao/tto/definitionSource> "“Weight.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/weight. Accessed 5 Dec. 2022."@en ;
-                                              rdfs:label "Gewicht"@de ,
-                                                         "Weight"@en ;
-                                              <http://www.w3.org/2004/02/skos/core#definition> "The force with which a body is attracted toward the earth or a celestial body by gravitation and which is equal to the product of the mass and the local gravitational acceleration."@en .
-
-
-###  http://material-digital.de/pmdao/tto/Width
-<http://material-digital.de/pmdao/tto/Width> rdf:type owl:Class ;
-                                             rdfs:subClassOf <http://material-digital.de/pmdao/tto/ValueObject> ;
-                                             <http://material-digital.de/pmdao/tto/definitionSource> "http://www.merriam-webster.com/dictionary/width"@en ;
-                                             rdfs:label "Breite"@de ,
-                                                        "Width"@en ;
-                                             <http://www.w3.org/2004/02/skos/core#definition> "Diese Eigenschaft bezeichnet eine horizontale Messung, die im rechten Winkel zur Länge eines Objekts vorgenommen wird."@de ,
-                                                                                              "This property describes a horizontal measurement of an object taken at right angles to the length of the object."@en .
-
-
-###  http://material-digital.de/pmdao/tto/WidthAfterFracture
-<http://material-digital.de/pmdao/tto/WidthAfterFracture> rdf:type owl:Class ;
-                                                          rdfs:subClassOf <http://material-digital.de/pmdao/tto/Width> ;
-                                                          rdfs:label "End-Breite"@de ,
-                                                                     "Width After Fracture"@en ;
-                                                          <http://www.w3.org/2004/02/skos/core#definition> "Diese Eigenschaft beschreibt eine horizontale Messung eines Objekts (Prüfkörpers) im rechten Winkel zur Länge des Objekts (Prüfkörpers), wie sie nach einer Prüfung gemessen wird."@de ,
-                                                                                                           "This property describes a horizontal measurement of an object (test piece) taken at right angles to the length of the object (test piece), as measured after a test."@en .
-
-
-###  http://material-digital.de/pmdao/tto/WorkingRange
-<http://material-digital.de/pmdao/tto/WorkingRange> rdf:type owl:Class ;
-                                                    rdfs:subClassOf <http://material-digital.de/pmdao/tto/ValueObject> ;
-                                                    rdfs:label "Arbeitsbereich"@de ,
-                                                               "Working Range"@en ;
-                                                    <http://www.w3.org/2004/02/skos/core#definition> "Diese Eigenschaft beschreibt den Bereich zwischen den Grenzen, innerhalb derer ein Prozessknoten (z. B. eine Maschine) für ihren vorgesehenen Zweck verwendet werden kann, ausgedrückt durch die Angabe der in Rede stehenden unteren und oberen Bereichswerte."@de ,
-                                                                                                     "This property describes the region between the limits within which a process node (e.g., a machine) is capable of being used for its intended purpose, expressed by stating the lower and upper range values of interest."@en .
-
-
-###  http://material-digital.de/pmdao/tto/YieldStrength
-<http://material-digital.de/pmdao/tto/YieldStrength> rdf:type owl:Class ;
-                                                     owl:equivalentClass [ rdf:type owl:Restriction ;
-                                                                           owl:onProperty <http://material-digital.de/pmdao/tto/relatesTo> ;
-                                                                           owl:someValuesFrom <http://material-digital.de/pmdao/tto/Stress>
-                                                                         ] ;
-                                                     rdfs:subClassOf <http://material-digital.de/pmdao/tto/ValueObject> ;
-                                                     <http://material-digital.de/pmdao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en ;
-                                                     rdfs:label "Streckgrenze"@de ,
-                                                                "Yield Strength"@en ;
-                                                     <http://www.w3.org/2004/02/skos/core#definition> "Wenn der metallische Werkstoff diese Eigenschaft aufweist: die Spannung zu einem bestimmten Zeitpunkt während des Versuchs bei dem eine plastische Verformung ohne Zunahme der Kraft auftritt"@de ,
-                                                                                                      "when the metallic material exhibits a yield phenomenon, stress corresponding to the point reached during the test at which plastic deformation occurs without any increase in the force"@en .
-
-
 ###  http://purl.obolibrary.org/obo/CHEBI_24431
 <http://purl.obolibrary.org/obo/CHEBI_24431> rdf:type owl:Class ;
-                                             <http://material-digital.de/pmdao/tto/definitionSource> "ChEBI ontology  http://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:24431#"@en ;
                                              rdfs:label "Chemical Entity"@en ;
-                                             <http://www.w3.org/2004/02/skos/core#definition> "A chemical entity is a physical entity of interest in chemistry including molecular entities, parts thereof, and chemical substances."@en .
+                                             <http://www.w3.org/2004/02/skos/core#definition> "A chemical entity is a physical entity of interest in chemistry including molecular entities, parts thereof, and chemical substances."@en ;
+                                             <http://w3id.org/pmd/ao/tto/definitionSource> "ChEBI ontology  http://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:24431#"@en .
 
 
 ###  http://qudt.org/schema/qudt/Unit
@@ -2778,6 +499,2285 @@ ex:spec1 :hasCharacteristic ex:vo1 ."""@en ,
                                           <http://www.w3.org/ns/prov#n> "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-types"^^xsd:anyURI .
 
 
+###  http://w3id.org/pmd/ao/tto/AccreditationDocument
+<http://w3id.org/pmd/ao/tto/AccreditationDocument> rdf:type owl:Class ;
+                                                    rdfs:subClassOf <http://w3id.org/pmd/ao/tto/Document> ;
+                                                    rdfs:label "Accreditation Document"@en ,
+                                                               "Akkreditierungsdokument"@de ;
+                                                    <http://www.w3.org/2004/02/skos/core#definition> "Diese Entität beschreibt ein Dokument, welches aussagt, dass einer Organisation, Person oder Einrichtung eine offizielle Konformität mit einer Norm anerkannt wurde. Dies kann z. B. Prozesse, Ausrüstungen oder ganze Laboratorien umfassen."@de ,
+                                                                                                     "This entity describes a document used to state that an official authorization or approval to recognize or vouch for a conformation with a standard was granted to an organization, person, or entity. This may include, e.g., processes, (sets of) equipment, or entire laboratories."@en ;
+                                                    <http://w3id.org/pmd/ao/tto/definitionSource> "http://www.merriam-webster.com/dictionary/accreditation"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/Acoustical
+<http://w3id.org/pmd/ao/tto/Acoustical> rdf:type owl:Class ;
+                                         rdfs:subClassOf <http://w3id.org/pmd/ao/tto/MaterialProperty> ;
+                                         rdfs:label "Acoustical"@en ,
+                                                    "Akustisch"@de ;
+                                         <http://www.w3.org/2004/02/skos/core#definition> "Acoustical is relating to the sense or organs of hearing, to sound, or to the science of sounds. Here specifically on the acoustic properties of a material."@en ,
+                                                                                          "Akustisch bezieht sich auf den Hörsinn oder die Hörorgane, auf Schall oder auf die Wissenschaft vom Schall. Hier spezifisch auf die akustischen Eigenschaften eines Materials."@de ;
+                                         <http://w3id.org/pmd/ao/tto/definitionSource> "“Acoustic.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/acoustic. Accessed 13 Jan. 2023."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/Address
+<http://w3id.org/pmd/ao/tto/Address> rdf:type owl:Class ;
+                                      rdfs:subClassOf <http://w3id.org/pmd/ao/tto/ValueObject> ;
+                                      rdfs:label "Address"@en ,
+                                                 "Adresse"@de ;
+                                      <http://www.w3.org/2004/02/skos/core#definition> "A place where a person or organization may be communicated with."@en ,
+                                                                                       "Ein Ort, an dem mit einer Person oder Organisation kommuniziert werden kann."@de ;
+                                      <http://w3id.org/pmd/ao/tto/definitionSource> "“Address.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/address. Accessed 16 Jan. 2023."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/AgingInterval
+<http://w3id.org/pmd/ao/tto/AgingInterval> rdf:type owl:Class ;
+                                            rdfs:subClassOf <http://w3id.org/pmd/ao/tto/AgingTime> ;
+                                            rdfs:label "Aging Interval"@en ,
+                                                       "Alterungsintervall"@de ;
+                                            <http://www.w3.org/2004/02/skos/core#definition> "Timespan a Temperature during  an Aging Process is hold."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/AgingProcess
+<http://w3id.org/pmd/ao/tto/AgingProcess> rdf:type owl:Class ;
+                                           rdfs:subClassOf <http://w3id.org/pmd/ao/tto/Process> ;
+                                           rdfs:label "Aging Process"@en ,
+                                                      "Alterungsprozess"@de ;
+                                           <http://www.w3.org/2004/02/skos/core#definition> "Das Aging oder Auslagern ist ein Anlassvorgang, der den Martensit (Härtungsgefüge) wieder duktil und verformbar macht. Dabei wird ein Agingvorgang genutzt, nämlich die Bildung von Ausscheidungen in Form von FeXCY - Carbiden"@de ,
+                                                                                            "The process of hardening an alloy by a method that causes a constituent to precipitate from solid solution."@en ;
+                                           <http://www.w3.org/2004/02/skos/core#example> "The Process of austenitizing and quenching a steel alloy to achieve a martensitic microstructure for hardness increase."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/AgingTemperature
+<http://w3id.org/pmd/ao/tto/AgingTemperature> rdf:type owl:Class ;
+                                               rdfs:subClassOf <http://w3id.org/pmd/ao/tto/Temperature> ;
+                                               rdfs:label "Aging Temperature"@en ,
+                                                          "Alterungstemperatur"@de ;
+                                               <http://www.w3.org/2004/02/skos/core#definition> "Variable Temperature during an Aging Process depending on the desired deposition formations."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/AgingTime
+<http://w3id.org/pmd/ao/tto/AgingTime> rdf:type owl:Class ;
+                                        rdfs:subClassOf <http://w3id.org/pmd/ao/tto/Time> ;
+                                        rdfs:label "Aging Time"@en ,
+                                                   "Alterungszeit"@de ;
+                                        <http://www.w3.org/2004/02/skos/core#definition> "The timespan that an Aging Process executes to completion."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/Algorithm
+<http://w3id.org/pmd/ao/tto/Algorithm> rdf:type owl:Class ;
+                                        rdfs:subClassOf <http://w3id.org/pmd/ao/tto/Method> ;
+                                        rdfs:label "Algorithm"@en ,
+                                                   "Algorithmus"@de ;
+                                        <http://www.w3.org/2004/02/skos/core#definition> "A procedure for solving a mathematical problem (as of finding the greatest common divisor) in a finite number of steps that frequently involves repetition of an operation."@en ;
+                                        <http://w3id.org/pmd/ao/tto/definitionSource> "“Algorithm.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/algorithm. Accessed 24 Nov. 2022."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/AmorphousStructure
+<http://w3id.org/pmd/ao/tto/AmorphousStructure> rdf:type owl:Class ;
+                                                 rdfs:subClassOf <http://w3id.org/pmd/ao/tto/MaterialStructure> ;
+                                                 rdfs:label "Amorphe Struktur"@de ,
+                                                            "Amorphous Structure"@en ;
+                                                 <http://www.w3.org/2004/02/skos/core#definition> "Amorphe Materialien haben eine innere Struktur, die aus miteinander verbundenen Strukturblöcken besteht, die den grundlegenden Struktureinheiten in der entsprechenden kristallinen Phase der gleichen Verbindung ähnlich sein können. Anders als bei kristallinen Materialien besteht jedoch keine langfristige Ordnung. Amorphe Materialien können daher nicht durch eine bestimmte Einheitszelle definiert werden. "@de ,
+                                                                                                  "Amorphous materials have an internal structure consisting of interconnected structural blocks that can be similar to the basic structural units found in the corresponding crystalline phase of the same compound. Unlike in crystalline materials, however, no long-range order exists. Amorphous materials therefore cannot be defined by a finite unit cell. "@en ;
+                                                 <http://w3id.org/pmd/ao/tto/definitionSource> "“Amorphous solid - Structure.” Wikipedia The Free Encyclopedia, http://en.wikipedia.org/wiki/Amorphous_solid. Accessed 13 Jan. 2023."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/AnalysingProcess
+<http://w3id.org/pmd/ao/tto/AnalysingProcess> rdf:type owl:Class ;
+                                               rdfs:subClassOf <http://w3id.org/pmd/ao/tto/Process> ;
+                                               rdfs:label "Analyseprozess"@de ,
+                                                          "Analysing Process"@en ;
+                                               <http://www.w3.org/2004/02/skos/core#definition> """A process that is driven by the primary intent to gain new measurements
+An analysis process is either a transformative process or a non-transformative process."""@en .
+
+
+###  http://w3id.org/pmd/ao/tto/Area
+<http://w3id.org/pmd/ao/tto/Area> rdf:type owl:Class ;
+                                   rdfs:subClassOf <http://w3id.org/pmd/ao/tto/ValueObject> ;
+                                   rdfs:label "Area"@en ,
+                                              "Fläche"@de ;
+                                   <http://www.w3.org/2004/02/skos/core#definition> "The extent or measurement of a surface."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/AssemblingProcess
+<http://w3id.org/pmd/ao/tto/AssemblingProcess> rdf:type owl:Class ;
+                                                rdfs:subClassOf <http://w3id.org/pmd/ao/tto/Process> ;
+                                                rdfs:label "Assemblierungsprozess"@de ,
+                                                           "Assembling Process"@en ;
+                                                <http://www.w3.org/2004/02/skos/core#definition> "A process to mount or demount a component."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/BaseMaterial
+<http://w3id.org/pmd/ao/tto/BaseMaterial> rdf:type owl:Class ;
+                                           rdfs:subClassOf <http://w3id.org/pmd/ao/tto/EngineeredMaterial> ;
+                                           rdfs:label "Ausgangsmaterial"@de ,
+                                                      "Base Material"@en ;
+                                           <http://www.w3.org/2004/02/skos/core#definition> "Diese Entität wird verwendet, um ein Material zu beschreiben, das als solches gegeben angenommen und am Anfang einer betrachteten Prozesskette verwendet wurde."@de ,
+                                                                                            "This entity is used to describe the material that was taken as granted as such and used in the beginning of a process chain under consideration."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/Biological
+<http://w3id.org/pmd/ao/tto/Biological> rdf:type owl:Class ;
+                                         rdfs:subClassOf <http://w3id.org/pmd/ao/tto/MaterialProperty> ;
+                                         rdfs:label "Biological"@en ,
+                                                    "Biologisch"@de ;
+                                         <http://www.w3.org/2004/02/skos/core#definition> "Biological is relating to biology or to life and living processes. Here specifically to the biological properties of a material."@en ,
+                                                                                          "Biologisch bezieht sich auf die Biologie oder auf das Leben und lebende Prozesse. Hier speziell auf die biologischen Eigenschaften eines Materials."@de ;
+                                         <http://w3id.org/pmd/ao/tto/definitionSource> "“Biological.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/biological. Accessed 13 Jan. 2023."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/Blank
+<http://w3id.org/pmd/ao/tto/Blank> rdf:type owl:Class ;
+                                    rdfs:subClassOf <http://w3id.org/pmd/ao/tto/EngineeredMaterial> ;
+                                    rdfs:label "Blank"@en ,
+                                               "Rohling"@de ;
+                                    <http://www.w3.org/2004/02/skos/core#definition> "A piece of material prepared to be made into something by a further operation."@en ;
+                                    <http://w3id.org/pmd/ao/tto/definitionSource> "“Blank.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/blank. Accessed 25 Nov. 2022."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/BondingType
+<http://w3id.org/pmd/ao/tto/BondingType> rdf:type owl:Class ;
+                                          rdfs:subClassOf <http://w3id.org/pmd/ao/tto/MaterialRelated> ;
+                                          rdfs:label "Bindungstyp"@de ,
+                                                     "BondingType"@en ;
+                                          <http://www.w3.org/2004/02/skos/core#definition> "Any of several forces, especially the ionic bond, covalent bond, and metallic bond, by which atoms or ions are bound in a molecule or crystal."@en ,
+                                                                                           "Eine von mehreren Bindungen, insbesondere die Ionenbindung, die kovalente Bindung und die Metallbindung, durch die Atome oder Ionen in einem Molekül oder Kristall gebunden sind."@de ;
+                                          <http://w3id.org/pmd/ao/tto/definitionSource> "\"Bond types.” American Heritage® Dictionary of the English Language, Fifth Edition, http://www.thefreedictionary.com/Bond+Types. Accessed 13 Jan. 2023."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/CalibrationDocument
+<http://w3id.org/pmd/ao/tto/CalibrationDocument> rdf:type owl:Class ;
+                                                  rdfs:subClassOf <http://w3id.org/pmd/ao/tto/Document> ;
+                                                  rdfs:label "Calibration Document"@en ,
+                                                             "Kalibrierschein"@de ,
+                                                             "Kalibrierungsdokument"@de ;
+                                                  <http://www.w3.org/2004/02/skos/core#definition> "Diese Entität beschreibt ein Dokument, welches Abweichungen eines Messgerätes oder einer Maßverkörperung gegenüber einem anderen Gerät oder einer anderen Maßverkörperung feststellt und dokumentiert. Typischerweise ist die Person, welche die Kalibrierung durchführte, angegeben."@de ,
+                                                                                                   "This entity describes a document used to state that a set of graduations to indicate values or positions has been performed. Typically, the calibration operator is included."@en ;
+                                                  <http://w3id.org/pmd/ao/tto/definitionSource> "http://www.merriam-webster.com/dictionary/calibration"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/CalibrationRange
+<http://w3id.org/pmd/ao/tto/CalibrationRange> rdf:type owl:Class ;
+                                               rdfs:subClassOf <http://w3id.org/pmd/ao/tto/ValueObject> ;
+                                               rdfs:label "Calibration range"@en ,
+                                                          "Kalibrierbereich"@de ;
+                                               <http://www.w3.org/2004/02/skos/core#definition> "Diese Eigenschaft beschreibt den Bereich zwischen den Grenzen, innerhalb derer eine Größe gemessen, empfangen oder übertragen wird (typischerweise von einem Prozessknoten, z. B. einer Maschine), ausgedrückt durch die Angabe des unteren und oberen Bereichswertes."@de ,
+                                                                                                "This property describes the region between the limits within which a quantity is measured, received or transmitted (typically by a process node, e.g. a machine), expressed by stating the lower and upper range values."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/Caliper
+<http://w3id.org/pmd/ao/tto/Caliper> rdf:type owl:Class ;
+                                      rdfs:subClassOf <http://w3id.org/pmd/ao/tto/MeasuringDevice> ;
+                                      rdfs:label "Caliper"@en ,
+                                                 "Messschieber"@de ;
+                                      <http://www.w3.org/2004/02/skos/core#definition> "any of various measuring instruments having two usually adjustable arms, legs, or jaws used especially to measure the dimensions of objects, such as diameters or thicknesses"@en ,
+                                                                                       "ein Messgerät mit zwei in der Regel verstellbaren Armen, Schenkeln oder Klemmbacken, das vor allem zur Messung der Abmessungen von Gegenständen, wie z. B. des Durchmessers oder der Dicke, verwendet wird"@de ;
+                                      <http://w3id.org/pmd/ao/tto/definitionSource> "http://www.merriam-webster.com/dictionary/caliper"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/ChangeOfTransverseDimension
+<http://w3id.org/pmd/ao/tto/ChangeOfTransverseDimension> rdf:type owl:Class ;
+                                                          rdfs:subClassOf <http://w3id.org/pmd/ao/tto/Length> ;
+                                                          rdfs:label "Change Of Transverse Dimension"@en ,
+                                                                     "Änderung der transversalen Dimension"@de ;
+                                                          <http://www.w3.org/2004/02/skos/core#definition> "Dieses Wertobjekt beschreibt eine Variation der Abmessungen eines Prüfkörpers in Bezug auf seine Querachse, die sich auf seine Querschnittsfläche auswirkt und möglicherweise während eines Zugversuchs auftritt. Das Verhältnis der wahren plastischen Breitendehnung und der wahren plastischen Dickendehnung in einem in uniaxialem Zug beanspruchten Prüfkörper (vertikale Anisotropie) kann anhand dieser Information berechnet werden."@de ,
+                                                                                                           "This value object describes a variation in the dimension of a test piece referring to its transversal axis affecting its cross-sectional area that may potentially occur during a tensile test. The ratio of the true plastic strain in width and the true plastic strain in thickness in a test piece loaded in uniaxial tension (vertical anisotropy) may be calculated using this information."@en ;
+                                                          <http://w3id.org/pmd/ao/tto/definitionSource> "DIN EN ISO 10113:2021-06" .
+
+
+###  http://w3id.org/pmd/ao/tto/Chemical
+<http://w3id.org/pmd/ao/tto/Chemical> rdf:type owl:Class ;
+                                       rdfs:subClassOf <http://w3id.org/pmd/ao/tto/MaterialProperty> ;
+                                       rdfs:label "Chemical"@en ,
+                                                  "Chemisch"@de ;
+                                       <http://www.w3.org/2004/02/skos/core#definition> "Chemical is relating to, used in, or produced by chemistry or the phenomena of chemistry Here specifically to the chemical properties of a material."@en ,
+                                                                                        "Chemisch ist ein Begriff, der sich auf die Chemie oder die chemischen Phänomene bezieht, in der Chemie verwendet wird oder durch sie erzeugt wird. Hier geht es speziell um die chemischen Eigenschaften eines Materials."@de ;
+                                       <http://w3id.org/pmd/ao/tto/definitionSource> "“Chemical.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/chemical. Accessed 13 Jan. 2023."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/ChemicalComposition
+<http://w3id.org/pmd/ao/tto/ChemicalComposition> rdf:type owl:Class ;
+                                                  owl:equivalentClass [ rdf:type owl:Restriction ;
+                                                                        owl:onProperty [ owl:inverseOf <http://purl.org/dc/terms/isPartOf>
+                                                                                       ] ;
+                                                                        owl:someValuesFrom <http://w3id.org/pmd/ao/tto/ChemicalObject>
+                                                                      ] ;
+                                                  rdfs:subClassOf <http://w3id.org/pmd/ao/tto/ValueObject> ;
+                                                  rdfs:label "Chemical Composition"@en ,
+                                                             "Chemische Zusammensetzung"@de ;
+                                                  <http://www.w3.org/2004/02/skos/core#definition> "Chemical composition refers to the arrangement, type, and ratio of atoms in molecules of chemical substances. Chemical composition varies when chemicals are added or subtracted from a substance, when the ratio of substances changes, or when other chemical changes occur in chemicals."@en ;
+                                                  <http://www.w3.org/2004/02/skos/core#example> """ex:proc1 a pmd:Process .
+ex:proc1 pmd:hasChacteristic ex:vo1 .
+
+ex:vo1 a ValueObject .
+ex:vo1 hasResource ex:chemComp1 .
+ex:chemComp1 a pmd:ChemicalComposition .
+
+ex:vo2 dcterm:partOf ex:chemComp1 .
+ex:vo2 a pmd:ChemicalElement .
+ex:vo2 pmd:relatesToElement CHEBI:28984 .
+ex:vo2 pmd:relatesTo ex:vo3 .
+
+pmd:MassFraction rdf:subClassOf ValueObject .
+ex:vo3 a pmd:MassFraction .
+ex:vo3 qudt:upperBound \"0.3\" .
+ex:vo3 qudt:lowerBound \"0\" .
+ex:vo3 qudt:hasUnit qudt:PERCENT .
+
+ex:vo4 a pmd:MassFraction .
+ex:vo4 pmd:hasResource pmd:NotDetected .""" ;
+                                                  <http://w3id.org/pmd/ao/tto/definitionSource> "http://chem.libretexts.org/Courses/College_of_Marin/CHEM_114%3A_Introductory_Chemistry/06%3A_Chemical_Composition" .
+
+
+###  http://w3id.org/pmd/ao/tto/ChemicalObject
+<http://w3id.org/pmd/ao/tto/ChemicalObject> rdf:type owl:Class ;
+                                             owl:equivalentClass [ owl:intersectionOf ( <http://w3id.org/pmd/ao/tto/ValueObject>
+                                                                                        [ rdf:type owl:Restriction ;
+                                                                                          owl:onProperty <http://w3id.org/pmd/ao/tto/relatesTo> ;
+                                                                                          owl:someValuesFrom <http://purl.obolibrary.org/obo/CHEBI_24431>
+                                                                                        ]
+                                                                                      ) ;
+                                                                   rdf:type owl:Class
+                                                                 ] ;
+                                             rdfs:subClassOf <http://w3id.org/pmd/ao/tto/ValueObject> ;
+                                             rdfs:label "Chemical Object"@en ,
+                                                        "Chemisches Objekt"@de ;
+                                             <http://www.w3.org/2004/02/skos/core#definition> "Value object that describes the quantity (e.g. mass fraction) of a specific chemical object."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/Circular
+<http://w3id.org/pmd/ao/tto/Circular> rdf:type owl:Class ;
+                                       rdfs:subClassOf <http://w3id.org/pmd/ao/tto/Shape> ;
+                                       rdfs:label "Circular"@en ,
+                                                  "Kreisförmig"@de ;
+                                       <http://www.w3.org/2004/02/skos/core#definition> "Geformt wie ein Kreis."@de ,
+                                                                                        "Having the form of a circle."@en ;
+                                       <http://w3id.org/pmd/ao/tto/definitionSource> "“Circular.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/circular. Accessed 13 Jan. 2023."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/ClampingPressure
+<http://w3id.org/pmd/ao/tto/ClampingPressure> rdf:type owl:Class ;
+                                               rdfs:subClassOf <http://w3id.org/pmd/ao/tto/Stress> ;
+                                               rdfs:label "Clamping Pressure"@en ,
+                                                          "Klemmdruck"@de ;
+                                               <http://www.w3.org/2004/02/skos/core#definition> "Diese Eigenschaft beschreibt als quantitativer Wert die Kraft pro Fläche (Druck), die beim Einbau einer Probe, eines Prüfkörpers oder eines Prüfstücks aufgebracht wird. Typischerweise ist das Aufbringen eines Klemmdrucks mit einer Art von Klemm- oder Spannzubehör (Grips) oder Ähnlichem verbunden."@de ,
+                                                                                                "This property describes the force per area (pressure) that is used during the mounting process of a sample, specimen, or test piece as a quantitative value. Typically, this process involves some sort of grips or the like."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/ClassificationDocument
+<http://w3id.org/pmd/ao/tto/ClassificationDocument> rdf:type owl:Class ;
+                                                     rdfs:subClassOf <http://w3id.org/pmd/ao/tto/Document> ;
+                                                     rdfs:label "Classification Document"@en ,
+                                                                "Klassifzierungsdokument"@de ;
+                                                     <http://www.w3.org/2004/02/skos/core#definition> "Diese Entität beschreibt ein Dokument, das dazu dient, den Arbeits- oder Anwendungsbereich eines Prozessknotens in Übereinstimmung mit genormten Abstufungen zu definieren."@de ,
+                                                                                                      "This entity describes a document used to define the working or application range of a process node in accordance with standardized graduations."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/CoatingDesignation
+<http://w3id.org/pmd/ao/tto/CoatingDesignation> rdf:type owl:Class ;
+                                                 rdfs:subClassOf <http://w3id.org/pmd/ao/tto/MaterialRelated> ;
+                                                 rdfs:label "Beschichtungsbezeichnung"@de ,
+                                                            "Coating Designation"@en ;
+                                                 <http://www.w3.org/2004/02/skos/core#definition> "Diese Eigenschaft ist ein Name oder Bezeichner eines Materialtyps, welcher den obersten Teil eines Bauteils (Beschichtung) bedeckt."@de ,
+                                                                                                  "This property is a name or identifier of a material type which designates the most upper part of a component (coating)."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/CollectionInterfaceHint
+<http://w3id.org/pmd/ao/tto/CollectionInterfaceHint> rdf:type owl:Class ;
+                                                      rdfs:subClassOf <http://w3id.org/pmd/ao/tto/NodeInfo> ;
+                                                      rdfs:label "Collection Interface Hint"@en ,
+                                                                 "Datenschnittstellenhinweis"@de ;
+                                                      <http://www.w3.org/2004/02/skos/core#definition> "A label in support of identifying a network interface and/or address used by a process node to provide primary data stored in ontologies"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/CommissionTime
+<http://w3id.org/pmd/ao/tto/CommissionTime> rdf:type owl:Class ;
+                                             rdfs:subClassOf <http://w3id.org/pmd/ao/tto/Time> ;
+                                             rdfs:label "Commission Time"@en ,
+                                                        "Kommissionszeit"@de ;
+                                             <http://www.w3.org/2004/02/skos/core#definition> "Date and time an order or plan has been dispatched at."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/Component
+<http://w3id.org/pmd/ao/tto/Component> rdf:type owl:Class ;
+                                        rdfs:subClassOf <http://w3id.org/pmd/ao/tto/Object> ;
+                                        rdfs:label "Component"@en ,
+                                                   "Komponente"@de ;
+                                        <http://www.w3.org/2004/02/skos/core#definition> "An object that serves a specific technical application. Constituent part of a compound of parts that builds a technical application"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/ConditioningProcess
+<http://w3id.org/pmd/ao/tto/ConditioningProcess> rdf:type owl:Class ;
+                                                  rdfs:subClassOf <http://w3id.org/pmd/ao/tto/Process> ;
+                                                  rdfs:label "Conditioning Process"@en ,
+                                                             "Konditionierungsprozess"@de ;
+                                                  <http://www.w3.org/2004/02/skos/core#definition> "Diese Eigenschaft beschreibt den Prozess und die Maßnahmen, die ergriffen werden, um einen materiellen Gegenstand auf vordefinierte Umgebungsbedingungen einzustellen."@de ,
+                                                                                                   "This property describes the process of and the measures taken to set a tangible object to pre-defined environmental conditions."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/CovalentBond
+<http://w3id.org/pmd/ao/tto/CovalentBond> rdf:type owl:Class ;
+                                           rdfs:subClassOf <http://w3id.org/pmd/ao/tto/BondingType> ;
+                                           rdfs:label "Covalent Bond"@en ,
+                                                      "Kovalente Bindung"@de ;
+                                           <http://www.w3.org/2004/02/skos/core#definition> "Covalent bond is a chemical bond formed between atoms by the sharing of electrons."@en ,
+                                                                                            "Eine kovalente Bindung ist eine chemische Verbindung zwischen Atomen, die durch die gemeinsame Nutzung von Elektronen entsteht."@de ;
+                                           <http://w3id.org/pmd/ao/tto/definitionSource> "\"Covalent bond.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/covalent%20bond. Accessed 13 Jan. 2023."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/CreepStress
+<http://w3id.org/pmd/ao/tto/CreepStress> rdf:type owl:Class ;
+                                          rdfs:subClassOf <http://w3id.org/pmd/ao/tto/Stress> ;
+                                          rdfs:label "Creep Stress"@en ,
+                                                     "Kriechspannung"@de ;
+                                          <http://www.w3.org/2004/02/skos/core#definition> "Is the strain occuring with time, when a constant force is applied to a physical body."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/CrossSectionArea
+<http://w3id.org/pmd/ao/tto/CrossSectionArea> rdf:type owl:Class ;
+                                               rdfs:subClassOf <http://w3id.org/pmd/ao/tto/Area> ;
+                                               rdfs:label "Cross Section Area"@en ,
+                                                          "Querschnittsfläche"@de ;
+                                               <http://www.w3.org/2004/02/skos/core#definition> "Diese Eigenschaft beschreibt die Fläche eines Schnittes oder eines rechtwinklig geschnittenen oder gebrochenen Stücks eines Objektes in Bezug auf eine Achse."@de ,
+                                                                                                "This property describes the area of a cutting or piece of an object cut off or broken at right angles or related to an axis."@en ;
+                                               <http://w3id.org/pmd/ao/tto/definitionSource> "http://www.merriam-webster.com/dictionary/cross%20section"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/CrossSectionDetermination
+<http://w3id.org/pmd/ao/tto/CrossSectionDetermination> rdf:type owl:Class ;
+                                                        rdfs:subClassOf <http://w3id.org/pmd/ao/tto/Method> ;
+                                                        rdfs:label "Cross Section Determination"@en ,
+                                                                   "Querschnittsermittlung"@de ;
+                                                        <http://www.w3.org/2004/02/skos/core#definition> """Cross section is a cutting or piece of something cut off at right angles to an axis
+also : a representation of such a cutting."""@en ;
+                                                        <http://www.w3.org/2004/02/skos/core#example> "Using the density of the test piece."@en ;
+                                                        <http://w3id.org/pmd/ao/tto/definitionSource> "“Cross section.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/cross%20section. Accessed 24 Nov. 2022."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/CrossheadSeparation
+<http://w3id.org/pmd/ao/tto/CrossheadSeparation> rdf:type owl:Class ;
+                                                  rdfs:subClassOf <http://w3id.org/pmd/ao/tto/ValueObject> ;
+                                                  rdfs:label "Crosshead Separation"@en ,
+                                                             "Querhaupttrennung"@de ;
+                                                  <http://www.w3.org/2004/02/skos/core#definition> "Diese Eigenschaft beschreibt die Verschiebung der Traverse einer Prüfmaschine."@de ,
+                                                                                                   """Dimensional analysis: L
+Unit (e.g. SI): mm"""@en ,
+                                                                                                   "This property describes the displacement of the crossheads of a testing machine."@en ;
+                                                  <http://w3id.org/pmd/ao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/CrossheadSeparationRate
+<http://w3id.org/pmd/ao/tto/CrossheadSeparationRate> rdf:type owl:Class ;
+                                                      rdfs:subClassOf <http://w3id.org/pmd/ao/tto/TestingRate> ;
+                                                      rdfs:label "Crosshead Separation Rate"@en ,
+                                                                 "Traversengeschwindigkeit"@de ;
+                                                      <http://www.w3.org/2004/02/skos/core#definition> "Symbol: v_c"@en ,
+                                                                                                       "Traversenweg je Zeiteinheit"@de ,
+                                                                                                       "displacement of the crossheads per time"@en ;
+                                                      <http://w3id.org/pmd/ao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/CrystallineStructure
+<http://w3id.org/pmd/ao/tto/CrystallineStructure> rdf:type owl:Class ;
+                                                   rdfs:subClassOf <http://w3id.org/pmd/ao/tto/MaterialStructure> ;
+                                                   rdfs:label "Crystalline Structure"@en ,
+                                                              "Kristalline Struktur"@de ;
+                                                   <http://www.w3.org/2004/02/skos/core#definition> "In crystallography, crystal structure is a description of the ordered arrangement of atoms, ions or molecules in a crystalline material. Ordered structures occur from the intrinsic nature of the constituent particles to form symmetric patterns that repeat along the principal directions of three-dimensional space in matter."@en ,
+                                                                                                    "In der Kristallographie ist die Kristallstruktur eine Beschreibung der geordneten Anordnung von Atomen, Ionen oder Molekülen in einem kristallinen Material. Geordnete Strukturen ergeben sich aus der intrinsischen Natur der konstituierenden Teilchen, die symmetrische Muster bilden, die sich entlang der Hauptrichtungen des dreidimensionalen Raums in der Materie wiederholen."@de ;
+                                                   <http://w3id.org/pmd/ao/tto/definitionSource> "“Crystal structure.” Wikipedia The Free Encyclopedia, http://en.wikipedia.org/wiki/Crystal_structure. Accessed 13 Jan. 2023."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/DataAcquisitionRate
+<http://w3id.org/pmd/ao/tto/DataAcquisitionRate> rdf:type owl:Class ;
+                                                  rdfs:subClassOf <http://w3id.org/pmd/ao/tto/ValueObject> ;
+                                                  rdfs:label "Data Acquisition Rate"@en ,
+                                                             "Datenerfassungsrate"@de ;
+                                                  <http://www.w3.org/2004/02/skos/core#definition> "Diese Eigenschaft bezeichnet die Anzahl der Messungen / Abfragen pro Zeiteinheit bei einer betrachteten Messung einer Messgröße (Abtast-/Abfragerate bei der Datenerfassung)."@de ,
+                                                                                                   "This property denotes the number of measurements / queries per time period for a considered measurement of a measurement parameter (sampling / query rate during data acquisition)."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/DataCiteMetadata
+<http://w3id.org/pmd/ao/tto/DataCiteMetadata> rdf:type owl:Class ;
+                                               rdfs:subClassOf <http://w3id.org/pmd/ao/tto/ValueObject> ;
+                                               rdfs:label "Data Cite Metadaten"@de ,
+                                                          "DataCite Metadata"@en ;
+                                               <http://www.w3.org/2004/02/skos/core#definition> "This value object refers to metadata which can be provided as DataCite element."@en ;
+                                               <http://www.w3.org/2004/02/skos/core#example> """For example, to refer to a ISBN number, following triples might be created:
+
+    :p1 a pmd:Process .
+    :p1 pmd:hasCharacteristic :doc_vo1 .
+    :doc_vo1 a pmd:Document .
+    :doc_vo1 pmd:hasCharacteristic :isbn_vo1 .
+    :doc_vo1 pmd:hasResource \"http://example.org/book.pdf\" .
+    :isbn_vo1 a pmd:DataCiteMetadata .
+    :isbn_vo1 pmd:relatesTo <http://purl.org/spar/datacite/isbn> .
+    :isbn_vo1 pmd:hasValue \"9780262012423\". 
+
+\"a document related to process :p1 has a ISBN number 9780262012423\""""@en .
+
+
+###  http://w3id.org/pmd/ao/tto/DataScope
+<http://w3id.org/pmd/ao/tto/DataScope> rdf:type owl:Class ;
+                                        rdfs:subClassOf <http://www.w3.org/ns/prov#Entity> ;
+                                        rdfs:label "Data Scope"@en ,
+                                                   "Datenkategorie"@de ;
+                                        <http://www.w3.org/2004/02/skos/core#definition> "This property is used to categorize data with respect to their intended usage in accordance with a regarded object or process."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/Date
+<http://w3id.org/pmd/ao/tto/Date> rdf:type owl:Class ;
+                                   rdfs:subClassOf <http://w3id.org/pmd/ao/tto/Time> ;
+                                   rdfs:label "Date"@en ,
+                                              "Datum"@de ;
+                                   <http://www.w3.org/2004/02/skos/core#definition> "A statement of the day of execution or making. Based on an the gregorian calender system."@en ,
+                                                                                    "Eine Erklärung über den Tag der Ausführung oder Herstellung. Basierend auf dem gregorianischen Kalendersystem."@de .
+
+
+###  http://w3id.org/pmd/ao/tto/DemountingProcess
+<http://w3id.org/pmd/ao/tto/DemountingProcess> rdf:type owl:Class ;
+                                                rdfs:subClassOf <http://w3id.org/pmd/ao/tto/AssemblingProcess> ;
+                                                rdfs:label "Demontageprozess"@de ,
+                                                           "Demounting Process"@en ;
+                                                <http://www.w3.org/2004/02/skos/core#definition> "This property is used to describe the process of removing or disassembling a test piece or specimen from a test machine. This may include the usage of other process nodes (e.g. grips)."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/Department
+<http://w3id.org/pmd/ao/tto/Department> rdf:type owl:Class ;
+                                         rdfs:subClassOf <http://www.w3.org/ns/prov#Organization> ;
+                                         rdfs:label "Abteilung"@de ,
+                                                    "Department"@en ;
+                                         <http://www.w3.org/2004/02/skos/core#definition> "A sub section of an organization [FIXME]"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/Description
+<http://w3id.org/pmd/ao/tto/Description> rdf:type owl:Class ;
+                                          rdfs:subClassOf <http://w3id.org/pmd/ao/tto/ValueObject> ;
+                                          rdfs:label "Beschreibung"@de ,
+                                                     "Description"@en ;
+                                          <http://www.w3.org/2004/02/skos/core#definition> "A descriptive text qualifying the nature of a thing (e.g. agent, activity, entity, object, ...)." ,
+                                                                                           "Ein beschreibender Text, der die Natur / Beschaffenheit / Informationen zu einer Entität qualifiziert (z.B. Aktivitäten, Entitäten, Objekten, ...)."@de .
+
+
+###  http://w3id.org/pmd/ao/tto/Diameter
+<http://w3id.org/pmd/ao/tto/Diameter> rdf:type owl:Class ;
+                                       rdfs:subClassOf <http://w3id.org/pmd/ao/tto/ValueObject> ;
+                                       rdfs:label "Diameter"@en ,
+                                                  "Durchmesser"@de ;
+                                       <http://www.w3.org/2004/02/skos/core#definition> "The length of a straight line through the center of an object or space."@en ;
+                                       <http://www.w3.org/ns/prov#constraints> "TesileTest" ;
+                                       <http://w3id.org/pmd/ao/tto/definitionSource> "“Diameter.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/diameter. Accessed 5 Dec. 2022."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/DiameterAfterFracture
+<http://w3id.org/pmd/ao/tto/DiameterAfterFracture> rdf:type owl:Class ;
+                                                    rdfs:subClassOf <http://w3id.org/pmd/ao/tto/Diameter> ;
+                                                    rdfs:label "Diameter After Fracture"@en ,
+                                                               "End-Probendurchmesser"@de ;
+                                                    <http://www.w3.org/2004/02/skos/core#definition> "Die Länge einer geraden Linie durch den Mittelpunkt eines Objekts (Prüfstücks), gemessen nach einem Bruch, der während einer Prüfung aufgetreten ist."@de ,
+                                                                                                     "The length of a straight line through the center of an object (test piece) as measured after a fracture occured during a test."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/DigitalMaterialIdentifier
+<http://w3id.org/pmd/ao/tto/DigitalMaterialIdentifier> rdf:type owl:Class ;
+                                                        owl:equivalentClass [ owl:intersectionOf ( <http://w3id.org/pmd/ao/tto/Identifier>
+                                                                                                   [ rdf:type owl:Restriction ;
+                                                                                                     owl:onProperty <http://w3id.org/pmd/ao/tto/hasResource> ;
+                                                                                                     owl:someValuesFrom <http://w3id.org/DMI/DigitalMaterialIdentifier>
+                                                                                                   ]
+                                                                                                 ) ;
+                                                                              rdf:type owl:Class
+                                                                            ] ;
+                                                        rdfs:subClassOf <http://w3id.org/pmd/ao/tto/Identifier> ;
+                                                        rdfs:label "Digital Material Identifier"@en ;
+                                                        <http://www.w3.org/2004/02/skos/core#definition> """The DigitalMaterialIdentifier value object refers to a dmi:DigitalMaterialIdentifier.
+
+A dmi:DigitalMaterialIdentifier is a resource identifier (IRI) that represents the specification of a material (in the sense of a material class) described in a specification document. The specification document can be, e.g., a standard, a datasheet, or any other citable document. Typically, a specification document requires some qualities that a material (in the sense of a portion of matter) has to comply with. Typical requirements include chemical compositions or physical properties."""@en .
+
+
+###  http://w3id.org/pmd/ao/tto/DimensionMeasuringDevice
+<http://w3id.org/pmd/ao/tto/DimensionMeasuringDevice> rdf:type owl:Class ;
+                                                       rdfs:subClassOf <http://w3id.org/pmd/ao/tto/MeasuringDevice> ;
+                                                       rdfs:label "Dimension Measuring Device"@en ,
+                                                                  "Dimensionsmesswerkzeug"@de ;
+                                                       <http://www.w3.org/2004/02/skos/core#definition> "Diese Entität beschreibt allgemein jedes Werkzeug, das für die Messung der Abmessungen eines greifbaren Objekts verwendet wird, z. B. eines Messschiebers."@de ,
+                                                                                                        "This entity generically describes any tool that is used for the measurement of the dimensions of a tangible object, e.g., a caliper."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/Distance
+<http://w3id.org/pmd/ao/tto/Distance> rdf:type owl:Class ;
+                                       rdfs:subClassOf <http://w3id.org/pmd/ao/tto/ValueObject> ;
+                                       rdfs:label "Abstand"@de ,
+                                                  "Distance"@en ;
+                                       <http://www.w3.org/2004/02/skos/core#definition> "Spatial remoteness."@en ;
+                                       <http://w3id.org/pmd/ao/tto/definitionSource> "“Distance.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/distance. Accessed 5 Dec. 2022."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/Document
+<http://w3id.org/pmd/ao/tto/Document> rdf:type owl:Class ;
+                                       rdfs:subClassOf <http://w3id.org/pmd/ao/tto/ValueObject> ;
+                                       rdfs:label "Document"@en ,
+                                                  "Dokument"@de ;
+                                       <http://www.w3.org/2004/02/skos/core#definition> "An original or official paper relied on as the basis, proof, or support of something"@en ,
+                                                                                        "Ein Original oder offizielles Papier, auf das man sich als Grundlage, Beweis oder Unterstützung von etwas stützt."@de ;
+                                       <http://w3id.org/pmd/ao/tto/definitionSource> "“Document.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/document. Accessed 16 Jan. 2023."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/Duration
+<http://w3id.org/pmd/ao/tto/Duration> rdf:type owl:Class ;
+                                       rdfs:subClassOf <http://w3id.org/pmd/ao/tto/Time> ;
+                                       rdfs:label "Dauer"@de ,
+                                                  "Duration"@en ;
+                                       <http://www.w3.org/2004/02/skos/core#definition> "A period of time with its own timescale and an epoch anchored in another timescale. A duration can be expressed via a single value as the first value of the period of time is always zero."@en ,
+                                                                                        "Eine Zeitspanne mit einer eigenen Zeitskala und einer in einer anderen Zeitskala verankerten Epoche. Eine Dauer kann mit einem einzigen Wert ausgedrückt werden, da der erste Wert der Zeitspanne immer Null ist."@de .
+
+
+###  http://w3id.org/pmd/ao/tto/Electrical
+<http://w3id.org/pmd/ao/tto/Electrical> rdf:type owl:Class ;
+                                         rdfs:subClassOf <http://w3id.org/pmd/ao/tto/MaterialProperty> ;
+                                         rdfs:label "Electrical"@en ,
+                                                    "Elektrisch"@de ;
+                                         <http://www.w3.org/2004/02/skos/core#definition> "Electrical is relating to electricity or something that is powered by electricity. Here specifically to the electrical properties of a material."@en ,
+                                                                                          "Elektrisch bezieht sich auf Elektrizität oder etwas, das mit Elektrizität betrieben wird. Hier speziell auf die elektrischen Eigenschaften eines Materials."@de ;
+                                         <http://w3id.org/pmd/ao/tto/definitionSource> "“Electric.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/electric. Accessed 13 Jan. 2023."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/Elliptical
+<http://w3id.org/pmd/ao/tto/Elliptical> rdf:type owl:Class ;
+                                         rdfs:subClassOf <http://w3id.org/pmd/ao/tto/Shape> ;
+                                         rdfs:label "Elliptical"@en ,
+                                                    "Elliptisch"@de ;
+                                         <http://www.w3.org/2004/02/skos/core#definition> "Geformt wie eine Ellipse."@de ,
+                                                                                          "Shaped like an ellipse."@en ;
+                                         <http://w3id.org/pmd/ao/tto/definitionSource> "“Elliptical.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/elliptical. Accessed 13 Jan. 2023."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/Elongation
+<http://w3id.org/pmd/ao/tto/Elongation> rdf:type owl:Class ;
+                                         owl:equivalentClass [ rdf:type owl:Restriction ;
+                                                               owl:onProperty <http://w3id.org/pmd/ao/tto/relatesTo> ;
+                                                               owl:someValuesFrom <http://w3id.org/pmd/ao/tto/OriginalGaugeLength>
+                                                             ] ;
+                                         rdfs:subClassOf <http://w3id.org/pmd/ao/tto/ValueObject> ;
+                                         rdfs:label "Elongation"@en ,
+                                                    "Verlängerung"@de ;
+                                         <http://www.w3.org/2004/02/skos/core#definition> "Zunahme der Anfangsmesslänge zu einem beliebigen Zeitpunkt während des Versuchs"@de ,
+                                                                                          "increase in the original gauge length at any moment during the test"@en ;
+                                         <http://w3id.org/pmd/ao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/EndTime
+<http://w3id.org/pmd/ao/tto/EndTime> rdf:type owl:Class ;
+                                      rdfs:subClassOf <http://w3id.org/pmd/ao/tto/Time> ;
+                                      rdfs:label "End Time"@en ,
+                                                 "Endzeit"@de ;
+                                      <http://www.w3.org/2004/02/skos/core#definition> "The date and time when the plan/recipe is supposed to have been finished"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/EngineeredMaterial
+<http://w3id.org/pmd/ao/tto/EngineeredMaterial> rdf:type owl:Class ;
+                                                 rdfs:subClassOf <http://w3id.org/pmd/ao/tto/Object> ;
+                                                 rdfs:label "Engineered Material"@en ;
+                                                 <http://www.w3.org/2004/02/skos/core#definition> "A material that is synthesized within a manufacturing process."@en ,
+                                                                                                  "Ein Material, das im Rahmen eines Herstellungsprozesses synthetisiert wird."@de .
+
+
+###  http://w3id.org/pmd/ao/tto/EngineeringStrain
+<http://w3id.org/pmd/ao/tto/EngineeringStrain> rdf:type owl:Class ;
+                                                owl:equivalentClass <http://w3id.org/pmd/ao/tto/PercentageExtension> ;
+                                                rdfs:subClassOf <http://w3id.org/pmd/ao/tto/ValueObject> ;
+                                                rdfs:label "Engineering Strain"@en ,
+                                                           "technische Dehnung"@de ;
+                                                <http://www.w3.org/2004/02/skos/core#definition> "Diese Eigenschaft bezieht sich auf den Grad der Verformung, den ein Material in Richtung der einwirkenden Kräfte im Verhältnis zu seiner ursprünglichen Länge aushält. Die technische Dehnung ist direkt proportional zum Betrag der Dehnung eines Objekts."@de ,
+                                                                                                 "This property refers to the degree of deformation that a material withstands in the direction of applied forces in relation to its original length. Engineering strain is directly proportional to the amount of elongation experienced by an object."@en ;
+                                                <http://w3id.org/pmd/ao/tto/definitionSource> "http://www.corrosionpedia.com/definition/6405/engineering-strain"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/EnvironmentalTemperature
+<http://w3id.org/pmd/ao/tto/EnvironmentalTemperature> rdf:type owl:Class ;
+                                                       rdfs:subClassOf <http://w3id.org/pmd/ao/tto/Temperature> ;
+                                                       rdfs:label "Environmental Temperature"@en ,
+                                                                  "Umgebungstemperatur"@de ;
+                                                       <http://www.w3.org/2004/02/skos/core#definition> "Diese Eigenschaft beschreibt die beobachtete Temperatur in der Umgebung eines betrachteten materiellen Objekts. Dazu können die Raumtemperatur und die in Prüfkammern gemessenen Temperaturen gehören."@de ,
+                                                                                                        "This property describes the observed temperature surrounding a tangible object considered. This may include room temperature and temperatures measured in test chambers."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/ErrorReportDocument
+<http://w3id.org/pmd/ao/tto/ErrorReportDocument> rdf:type owl:Class ;
+                                                  rdfs:subClassOf <http://w3id.org/pmd/ao/tto/Document> ;
+                                                  rdfs:label "Error Report Document"@en ,
+                                                             "Fehlerberichtdokument"@de ;
+                                                  <http://www.w3.org/2004/02/skos/core#definition> "Diese Entität beschreibt ein Dokument, das Informationen über Fehler bereitstellt, die während der Anwendung eines Prozessknotens aufgetreten sind, wie z. B. eine Überschreitung des Arbeitsbereichs eines Messgeräts."@de ,
+                                                                                                   "This entity describes a document used to provide information on errors that occurred during the application of a process node, such as, e.g., an overshooting exceeding the working range of a measurement device."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/EstimatedStrainRateOverTheParallelLength
+<http://w3id.org/pmd/ao/tto/EstimatedStrainRateOverTheParallelLength> rdf:type owl:Class ;
+                                                                       rdfs:subClassOf <http://w3id.org/pmd/ao/tto/TestingRate> ;
+                                                                       rdfs:label "Abgeschätzte Dehngeschwindigkeit Über Die Parallele Länge"@de ,
+                                                                                  "Estimated Strain Rate Over The Parallel Length"@en ;
+                                                                       <http://www.w3.org/2004/02/skos/core#definition> "Symbol: e^._L_c"@en ,
+                                                                                                                        "Zunahme der Dehnung über die parallele Länge der Probe je Zeiteinheit, basierend auf der Traversengeschwindigkeit und der parallelen Länge der Probe"@de ,
+                                                                                                                        "value of the increase of strain over the parallel length of the test piece per time based on the crosshead separation rate and the parallel length of the test piece"@en ;
+                                                                       <http://w3id.org/pmd/ao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/Extension
+<http://w3id.org/pmd/ao/tto/Extension> rdf:type owl:Class ;
+                                        owl:equivalentClass [ rdf:type owl:Restriction ;
+                                                              owl:onProperty <http://w3id.org/pmd/ao/tto/relatesTo> ;
+                                                              owl:someValuesFrom <http://w3id.org/pmd/ao/tto/ExtensometerGaugeLength>
+                                                            ] ;
+                                        rdfs:subClassOf <http://w3id.org/pmd/ao/tto/ValueObject> ;
+                                        rdfs:label "Extension"@en ,
+                                                   "Verlängerung (der Extensometer-Messlänge)"@de ;
+                                        <http://www.w3.org/2004/02/skos/core#definition> """Dimensional analysis: L
+Unit (e.g. SI): mm"""@en ,
+                                                                                         "Increase in the extensometer gauge length at any moment during the test"@en ,
+                                                                                         """Note: The extension might be measured using different channels (e.g. when using one or two extensometer channels); usually, the mean average value of involved channels is given as extension value, if applicable.
+
+Note: Optical extensometry may require a specific data storage method."""@en ,
+                                                                                         "Zunahme der Extensometer-Messlänge zu einem beliebigen Zeitpunkt des Versuchs"@de ;
+                                        <http://w3id.org/pmd/ao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/Extensometer
+<http://w3id.org/pmd/ao/tto/Extensometer> rdf:type owl:Class ;
+                                           rdfs:subClassOf <http://w3id.org/pmd/ao/tto/MeasuringDevice> ;
+                                           rdfs:label "Extensometer"@en ;
+                                           <http://www.w3.org/2004/02/skos/core#definition> "An instrument for measuring minute deformations of test specimens caused by tension, compression, bending, or twisting."@en ;
+                                           <http://w3id.org/pmd/ao/tto/definitionSource> "“Extensometer.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/extensometer. Accessed 5 Dec. 2022."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/ExtensometerGaugeLength
+<http://w3id.org/pmd/ao/tto/ExtensometerGaugeLength> rdf:type owl:Class ;
+                                                      rdfs:subClassOf <http://w3id.org/pmd/ao/tto/GaugeLength> ;
+                                                      rdfs:label "Extensometer Gauge Length"@en ,
+                                                                 "Extensometer-Messlänge"@de ;
+                                                      <http://www.w3.org/2004/02/skos/core#definition> """Anfangsmesslänge des Dehnungsaufnehmers (Extensometer), die zum Messen der Verlängerung benutzt wird
+
+Anmerkung: Für die Bestimmung mehrerer Eigenschaften, die (teilweise oder vollständig) von der Verlängerung abhängig sind, z. B. R_p, A_e oder A_g, ist die Verwendung eines Extensometers zwingend erforderlich."""@de ,
+                                                                                                       "Symbol: L_e"@en ,
+                                                                                                       """initial gauge length of the extensometer used for measurement of extension
+
+Note: For the determination of several properties which are based (partly or complete) on extension, e. g. R_p, A_e or A_g, the use of an extensometer is mandatory."""@en ;
+                                                      <http://w3id.org/pmd/ao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/Filter
+<http://w3id.org/pmd/ao/tto/Filter> rdf:type owl:Class ;
+                                     rdfs:subClassOf <http://w3id.org/pmd/ao/tto/Algorithm> ;
+                                     rdfs:label "Filter"@de ,
+                                                "Filter"@en ;
+                                     <http://www.w3.org/2004/02/skos/core#definition> "A filter is a computer program or subroutine to process a stream, producing another stream. While a single filter can be used individually, they are frequently strung together to form a pipeline."@en ;
+                                     <http://www.w3.org/2004/02/skos/core#example> "Smoothing algorithm"@en ;
+                                     <http://w3id.org/pmd/ao/tto/definitionSource> "http://en.wikipedia.org/wiki/Filter_%28software%29"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/FinalGaugeLengthAfterFracture
+<http://w3id.org/pmd/ao/tto/FinalGaugeLengthAfterFracture> rdf:type owl:Class ;
+                                                            rdfs:subClassOf <http://w3id.org/pmd/ao/tto/GaugeLength> ;
+                                                            rdfs:label "Final Gauge Length After Fracture"@en ,
+                                                                       "Messlänge nach dem Bruch"@de ,
+                                                                       "Symbol: L_u"@en ;
+                                                            <http://www.w3.org/2004/02/skos/core#definition> "Länge zwischen den Marken zur Kennzeichnung der Messlänge auf der Probe, die nach dem Bruch bei Raumtemperatur gemessen wird, nachdem die beiden Probenbruchstücke sorgfältig so zusammengefügt wurden, dass ihre Achsen in einer Geraden liegen"@de ,
+                                                                                                             "length between gauge length marks on the test piece measured after rupture, at room temperature, the two pieces having been carefully fitted back together so that their axes lie in a straight line"@en ;
+                                                            <http://w3id.org/pmd/ao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/FinalProcess
+<http://w3id.org/pmd/ao/tto/FinalProcess> rdf:type owl:Class ;
+                                           owl:equivalentClass [ owl:intersectionOf ( <http://w3id.org/pmd/ao/tto/Process>
+                                                                                      [ rdf:type owl:Restriction ;
+                                                                                        owl:onProperty <http://w3id.org/pmd/ao/tto/hasNextProcess> ;
+                                                                                        owl:maxQualifiedCardinality "0"^^xsd:nonNegativeInteger ;
+                                                                                        owl:onClass <http://w3id.org/pmd/ao/tto/Process>
+                                                                                      ]
+                                                                                    ) ;
+                                                                 rdf:type owl:Class
+                                                               ] ;
+                                           rdfs:subClassOf <http://w3id.org/pmd/ao/tto/Process> ;
+                                           rdfs:label "Final Process"@en ,
+                                                      "Finaler Prozess"@de ;
+                                           <http://www.w3.org/2004/02/skos/core#definition> "Diese Klasse wird verwendet, um den letzten von einem Prozessknoten durchgeführten Prozess in einer Reihe von Prozessen anzugeben, die von demselben Prozessknoten durchgeführt werden."@de ,
+                                                                                            "This class is used to indicate the last process conducted by a process node in a series of processes conducted by the same process node."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/Force
+<http://w3id.org/pmd/ao/tto/Force> rdf:type owl:Class ;
+                                    rdfs:subClassOf <http://w3id.org/pmd/ao/tto/ValueObject> ;
+                                    rdfs:label "Force"@en ,
+                                               "Kraft"@de ;
+                                    <http://www.w3.org/2004/02/skos/core#definition> "Strength or energy exerted or brought to bear : cause of motion or change : active power."@en ;
+                                    <http://w3id.org/pmd/ao/tto/definitionSource> "“Force.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/force. Accessed 5 Dec. 2022."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/GaugeLength
+<http://w3id.org/pmd/ao/tto/GaugeLength> rdf:type owl:Class ;
+                                          rdfs:subClassOf <http://w3id.org/pmd/ao/tto/Length> ;
+                                          rdfs:label "Gauge Length"@en ,
+                                                     "Messlänge"@de ;
+                                          <http://www.w3.org/2004/02/skos/core#definition> "Länge des parallelen Teils der Probe, an dem zu einem beliebigen Zeitpunkt während des Versuchs die Verlängerung gemessen wird"@de ,
+                                                                                           "Symbol: L"@en ,
+                                                                                           "length of the parallel portion of the test piece on which elongation is measured at any moment during the test"@en ;
+                                          <http://w3id.org/pmd/ao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/GeometryShape
+<http://w3id.org/pmd/ao/tto/GeometryShape> rdf:type owl:Class ;
+                                            rdfs:subClassOf <http://w3id.org/pmd/ao/tto/TestPieceInfo> ;
+                                            rdfs:label "Geometrische Form"@de ,
+                                                       "Geometry Shape"@en ;
+                                            <http://www.w3.org/2004/02/skos/core#definition> "Diese Eigenschaft beschreibt die geometrischen Abmessungen und das Erscheinungsbild (Form und Abmaße) einer Probe, eines Prüfkörpers oder eines Prüfstücks, wie sie üblicherweise durch eine entsprechende Norm definiert sind. Dementsprechend ist der angegebene Formwert in Übereinstimmung mit der definierenden Norm anzugeben, z. B. \"Zugprüfstück Form 1 gemäß Anhang B\"."@de ,
+                                                                                             "This property describes the geometric dimensions and appearance (shape and dimensions) of a sample, specimen, or test piece as usually defined by a corresponding standard. Accordingly, the shape value given is in accordance with the defining standard, e.g., ‘tensile test piece shape 1 in accordance with annex B’."@en ;
+                                            <http://w3id.org/pmd/ao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/Grips
+<http://w3id.org/pmd/ao/tto/Grips> rdf:type owl:Class ;
+                                    rdfs:subClassOf <http://w3id.org/pmd/ao/tto/ProcessingNode> ;
+                                    rdfs:label "Grips"@en ,
+                                               "Halterungsklemmen"@de ;
+                                    <http://www.w3.org/2004/02/skos/core#definition> "Diese Entität beschreibt ein Bauelement / Teil, mit dem etwas, normalerweise ein materielles Objekt, fest gegriffen oder eingespannt wird. Typischerweise sind Halterungen, Klemm- bzw. Spannsysteme Teil eines Befestigungssystems (Prozessknoten), das sich auf ein Prüfsystem bezieht."@de ,
+                                                                                     "This entity describes a part by which something, usually a tangible object, is grasped. Typically, grips are part of a mounting system (process node) referring to a testing system."@en ;
+                                    <http://w3id.org/pmd/ao/tto/definitionSource> "http://www.merriam-webster.com/dictionary/grips"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/GripsAlignment
+<http://w3id.org/pmd/ao/tto/GripsAlignment> rdf:type owl:Class ;
+                                             rdfs:subClassOf <http://w3id.org/pmd/ao/tto/QualifyingNodeAnnotation> ;
+                                             rdfs:label "Ausrichtung Der Halterungen"@de ,
+                                                        "Grips Alignment"@en ;
+                                             <http://www.w3.org/2004/02/skos/core#definition> "Diese Eigenschaft beschreibt den Prozess der Ausrichtung von Halterungen, die zum Fest-/Einspannen eines materiellen Objekts, wie z. B. einer Probe, eines Prüfkörpers oder eines Prüfstücks, verwendet werden. Dieser Vorgang ist in der Regel Teil des Montageprozesses während der Prüfung, falls ein solcher durchgeführt wird."@de ,
+                                                                                              "This property describes the process of forming in line of the grips used to grasp a tangible object, such as a sample, specimen, or test piece. This process is typically part of the mounting process during testing, if applicable."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/HeatTreatmentProcess
+<http://w3id.org/pmd/ao/tto/HeatTreatmentProcess> rdf:type owl:Class ;
+                                                   rdfs:subClassOf <http://w3id.org/pmd/ao/tto/ConditioningProcess> ;
+                                                   rdfs:label "Heat Treatment Process"@en ,
+                                                              "Wärmebehandlung"@de ;
+                                                   <http://www.w3.org/2004/02/skos/core#definition> "The process of heat treatment means a defined temperature change and a holding to achieve a change in the microstructure, residual stresses, defect distribution or local chemical composition of a material."@en ,
+                                                                                                    "To treat (a material, such as metal) by heating and cooling in a way that will produce desired properties."@en ;
+                                                   <http://w3id.org/pmd/ao/tto/definitionSource> "“Heat-treat.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/heat-treat. Accessed 24 Nov. 2022."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/HydrogenBond
+<http://w3id.org/pmd/ao/tto/HydrogenBond> rdf:type owl:Class ;
+                                           rdfs:subClassOf <http://w3id.org/pmd/ao/tto/BondingType> ;
+                                           rdfs:label "Hydrogen Bond"@en ,
+                                                      "Wasserstoffbindung"@de ;
+                                           <http://www.w3.org/2004/02/skos/core#definition> "Eine Wasserstoffbindung ist eine elektrostatische Anziehung zwischen einem Wasserstoffatom in einem polaren Molekül (z. B. Wasser) und einem kleinen elektronegativen Atom (z. B. Sauerstoff, Stickstoff oder Fluor) in einem anderen Molekül der gleichen oder einer anderen polaren Substanz."@de ,
+                                                                                            "Hydrogen bond is an electrostatic attraction between a hydrogen atom in one polar molecule (as of water) and a small electronegative atom (as of oxygen, nitrogen, or fluorine) in usually another molecule of the same or a different polar substance."@en ;
+                                           <http://w3id.org/pmd/ao/tto/definitionSource> "\"Hydrogen bond.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/hydrogen%20bond. Accessed 13 Jan. 2023."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/ISO6892-1TensileTest
+<http://w3id.org/pmd/ao/tto/ISO6892-1TensileTest> rdf:type owl:Class ;
+                                                   owl:equivalentClass [ rdf:type owl:Restriction ;
+                                                                         owl:onProperty <http://w3id.org/pmd/ao/tto/hasCharacteristic> ;
+                                                                         owl:someValuesFrom [ owl:intersectionOf ( <http://w3id.org/pmd/ao/tto/Norm>
+                                                                                                                   [ rdf:type owl:Restriction ;
+                                                                                                                     owl:onProperty <http://w3id.org/pmd/ao/tto/hasValue> ;
+                                                                                                                     owl:hasValue "ISO6892-1"
+                                                                                                                   ]
+                                                                                                                 ) ;
+                                                                                              rdf:type owl:Class
+                                                                                            ]
+                                                                       ] ,
+                                                                       [ rdf:type owl:Restriction ;
+                                                                         owl:onProperty <http://w3id.org/pmd/ao/tto/hasParticipant> ;
+                                                                         owl:someValuesFrom <http://w3id.org/pmd/ao/tto/Extensometer>
+                                                                       ] ,
+                                                                       [ rdf:type owl:Restriction ;
+                                                                         owl:onProperty <http://w3id.org/pmd/ao/tto/hasParticipant> ;
+                                                                         owl:someValuesFrom <http://w3id.org/pmd/ao/tto/LoadCell>
+                                                                       ] ,
+                                                                       [ rdf:type owl:Restriction ;
+                                                                         owl:onProperty <http://w3id.org/pmd/ao/tto/hasParticipant> ;
+                                                                         owl:someValuesFrom <http://w3id.org/pmd/ao/tto/TensileTestingMachine>
+                                                                       ] ,
+                                                                       [ rdf:type owl:Restriction ;
+                                                                         owl:onProperty <http://w3id.org/pmd/ao/tto/hasParticipant> ;
+                                                                         owl:someValuesFrom <http://w3id.org/pmd/ao/tto/TestPiece>
+                                                                       ] ;
+                                                   rdfs:subClassOf <http://w3id.org/pmd/ao/tto/TensileTest> ;
+                                                   rdfs:label "Tensile Test in accordance with ISO 6892-1"@en ,
+                                                              "Zugversuch nach ISO 6892-1"@de .
+
+
+###  http://w3id.org/pmd/ao/tto/Identifier
+<http://w3id.org/pmd/ao/tto/Identifier> rdf:type owl:Class ;
+                                         rdfs:subClassOf <http://w3id.org/pmd/ao/tto/ValueObject> ;
+                                         rdfs:label "Identifier"@en ,
+                                                    "Identifikator"@de ;
+                                         <http://www.w3.org/2004/02/skos/core#definition> "A named value intended to distinguish between entities."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/Image
+<http://w3id.org/pmd/ao/tto/Image> rdf:type owl:Class ;
+                                    rdfs:subClassOf <http://w3id.org/pmd/ao/tto/Object> ;
+                                    rdfs:label "Bild"@de ,
+                                               "Image"@en ;
+                                    <http://www.w3.org/2004/02/skos/core#definition> "A visual representation of something"@en ;
+                                    <http://w3id.org/pmd/ao/tto/definitionSource> "“Image.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/image. Accessed 25 Nov. 2022."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/Index
+<http://w3id.org/pmd/ao/tto/Index> rdf:type owl:Class ;
+                                    rdfs:subClassOf <http://w3id.org/pmd/ao/tto/ValueObject> ;
+                                    rdfs:label "Index"@de ,
+                                               "Index"@en ;
+                                    <http://www.w3.org/2004/02/skos/core#definition> "Some running number."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/Initiator
+<http://w3id.org/pmd/ao/tto/Initiator> rdf:type owl:Class ;
+                                        rdfs:subClassOf <http://www.w3.org/ns/prov#Person> ;
+                                        rdfs:label "Initiator"@de ,
+                                                   "Initiator"@en ;
+                                        <http://www.w3.org/2004/02/skos/core#definition> "The Person that commisioned the process."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/InsertSurface
+<http://w3id.org/pmd/ao/tto/InsertSurface> rdf:type owl:Class ;
+                                            rdfs:subClassOf <http://w3id.org/pmd/ao/tto/QualifyingNodeAnnotation> ;
+                                            rdfs:label "Insert Surface"@en ,
+                                                       "Oberfläche Eines Einsatzstücks"@de ;
+                                            <http://www.w3.org/2004/02/skos/core#definition> "Diese Entität beschreibt den Zustand und die Qualität des Außenbereichs des Einsatzes eines Prozessknotens, z. B. die in Klemm- und Spannsystemen verwendeten Einsätze."@de ,
+                                                                                             "This entity describes the state and quality of the exterior of the insert of a process node, e.g., the inserts used in grips."@en ;
+                                            <http://w3id.org/pmd/ao/tto/definitionSource> "http://www.merriam-webster.com/dictionary/surface"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/InspectionDocument
+<http://w3id.org/pmd/ao/tto/InspectionDocument> rdf:type owl:Class ;
+                                                 rdfs:subClassOf <http://w3id.org/pmd/ao/tto/Document> ;
+                                                 rdfs:label "Inspection Document"@en ,
+                                                            "Inspektionsdokument"@de ;
+                                                 <http://www.w3.org/2004/02/skos/core#definition> "Diese Entität beschreibt ein Dokument, das Informationen über die Prüfung eines materiellen Objekts enthält, in der Regel versehen mit einem Prüfungsdatum, einem typischen Prüfungsintervall und dem Zustand des geprüften Objekts. Typischerweise wird ein solches Dokument für Prozessknoten verwendet."@de ,
+                                                                                                  "This entity describes a document used to give information on the examination of a tangible object, usually including an examination date, a typical examination interval and the state of the examined object. Typically, this is used for process nodes."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/IonicBond
+<http://w3id.org/pmd/ao/tto/IonicBond> rdf:type owl:Class ;
+                                        rdfs:subClassOf <http://w3id.org/pmd/ao/tto/BondingType> ;
+                                        rdfs:label "Ionic Bond"@en ,
+                                                   "Ionische Bindung"@de ;
+                                        <http://www.w3.org/2004/02/skos/core#definition> "Eine Ionenbindung ist eine chemische Bindung, die zwischen entgegengesetzt geladenen Stoffen aufgrund ihrer gegenseitigen elektrostatischen Anziehung entsteht."@de ,
+                                                                                         "Ionic bond is a chemical bond formed between oppositely charged species because of their mutual electrostatic attraction."@en ;
+                                        <http://w3id.org/pmd/ao/tto/definitionSource> "\"Ionic bond.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/ionic%20bond. Accessed 13 Jan. 2023."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/Laboratory
+<http://w3id.org/pmd/ao/tto/Laboratory> rdf:type owl:Class ;
+                                         rdfs:subClassOf <http://www.w3.org/ns/prov#Organization> ;
+                                         rdfs:label "Labor"@de ,
+                                                    "Laboratory"@en ;
+                                         <http://www.w3.org/2004/02/skos/core#definition> "A place equipped for experimental study in a science or for testing and analysis."@en ;
+                                         <http://w3id.org/pmd/ao/tto/definitionSource> "“Laboratory.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/laboratory. Accessed 24 Nov. 2022."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/Length
+<http://w3id.org/pmd/ao/tto/Length> rdf:type owl:Class ;
+                                     rdfs:subClassOf <http://w3id.org/pmd/ao/tto/ValueObject> ;
+                                     rdfs:label "Length"@en ,
+                                                "Länge"@de ;
+                                     <http://www.w3.org/2004/02/skos/core#definition> "A measured distance or dimension of an object, usually the longer or longest dimension of the object."@en ,
+                                                                                      "Eine gemessene Entfernung oder Abmessung eines Objekts, normalerweise die längere oder längste Abmessung des Objekts."@de ;
+                                     <http://w3id.org/pmd/ao/tto/definitionSource> "http://www.merriam-webster.com/dictionary/length"@de .
+
+
+###  http://w3id.org/pmd/ao/tto/LoadCell
+<http://w3id.org/pmd/ao/tto/LoadCell> rdf:type owl:Class ;
+                                       rdfs:subClassOf <http://w3id.org/pmd/ao/tto/ProcessingNode> ;
+                                       rdfs:label "Kraftmessdose"@de ,
+                                                  "Load Cell"@en ;
+                                       <http://www.w3.org/2004/02/skos/core#definition> "A load cell converts a force such as tension, compression, pressure, or torque into an electrical signal that can be measured and standardized. It is a force transducer. As the force applied to the load cell increases, the electrical signal changes proportionally. The most common types of load cell are pneumatic, hydraulic, and strain gauges."@en ;
+                                       <http://w3id.org/pmd/ao/tto/definitionSource> "http://en.wikipedia.org/wiki/Load_cell"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/Location
+<http://w3id.org/pmd/ao/tto/Location> rdf:type owl:Class ;
+                                       rdfs:subClassOf <http://w3id.org/pmd/ao/tto/ValueObject> ;
+                                       rdfs:label "Location"@en ,
+                                                  "Ort"@de ;
+                                       <http://www.w3.org/2004/02/skos/core#definition> "A position or site occupied or available for occupancy or marked by some distinguishing feature."@en ,
+                                                                                        "Eine Position oder ein Ort, der besetzt ist oder besetzt werden kann oder durch ein bestimmtes Merkmal gekennzeichnet ist."@de ;
+                                       <http://w3id.org/pmd/ao/tto/definitionSource> "“Location.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/location. Accessed 17 Jan. 2023."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/LowerYieldStrength
+<http://w3id.org/pmd/ao/tto/LowerYieldStrength> rdf:type owl:Class ;
+                                                 owl:equivalentClass [ rdf:type owl:Restriction ;
+                                                                       owl:onProperty <http://w3id.org/pmd/ao/tto/relatesTo> ;
+                                                                       owl:someValuesFrom <http://w3id.org/pmd/ao/tto/Stress>
+                                                                     ] ;
+                                                 rdfs:subClassOf <http://w3id.org/pmd/ao/tto/YieldStrength> ;
+                                                 rdfs:label "Lower Yield Strength"@en ,
+                                                            "untere Streckgrenze"@de ;
+                                                 <http://www.w3.org/2004/02/skos/core#definition> "Symbol: R_eL"@en ,
+                                                                                                  "kleinste Spannung während des plastischen Fließens, wobei Einschwingerscheinungen nicht berücksichtigt werden"@de ,
+                                                                                                  "lowest value of stress during plastic yielding, ignoring any initial transient effects"@en ;
+                                                 <http://w3id.org/pmd/ao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/Magnetic
+<http://w3id.org/pmd/ao/tto/Magnetic> rdf:type owl:Class ;
+                                       rdfs:subClassOf <http://w3id.org/pmd/ao/tto/MaterialProperty> ;
+                                       rdfs:label "Magnetic"@en ,
+                                                  "Magnetisch"@de ;
+                                       <http://www.w3.org/2004/02/skos/core#definition> "Magnetic is relating relating to a magnet or to magnetism. Here specifically to the magnetic properties of a material."@en ,
+                                                                                        "Magnetisch bezieht sich auf einen Magneten oder auf Magnetismus. Hier speziell auf die magnetischen Eigenschaften eines Materials."@de ;
+                                       <http://w3id.org/pmd/ao/tto/definitionSource> "“Magnetic.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/magnetic. Accessed 13 Jan. 2023."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/Manufacturer
+<http://w3id.org/pmd/ao/tto/Manufacturer> rdf:type owl:Class ;
+                                           rdfs:subClassOf <http://www.w3.org/ns/prov#Organization> ;
+                                           rdfs:label "Hersteller"@de ,
+                                                      "Manufacturer"@en ;
+                                           <http://www.w3.org/2004/02/skos/core#definition> "Process Node's manufacturer name, e.g.: \"Ipsen\", \"UPC\" or \"Bosch\""@en .
+
+
+###  http://w3id.org/pmd/ao/tto/ManufacturingNode
+<http://w3id.org/pmd/ao/tto/ManufacturingNode> rdf:type owl:Class ;
+                                                rdfs:subClassOf <http://w3id.org/pmd/ao/tto/ProcessingNode> ;
+                                                rdfs:label "Herstellungsknoten"@de ,
+                                                           "Manufacturing Node"@en ;
+                                                <http://www.w3.org/2004/02/skos/core#definition> """A process node that implements transformative processes as well as consumes and creates tangible objects and typically requires inputs
+In general but not necessarily, a manufacture node includes intrinsic analysis nodes that create corresponding measurements with respect to the process implemented by the manufacture node."""@en .
+
+
+###  http://w3id.org/pmd/ao/tto/ManufacturingProcess
+<http://w3id.org/pmd/ao/tto/ManufacturingProcess> rdf:type owl:Class ;
+                                                   rdfs:subClassOf <http://w3id.org/pmd/ao/tto/Process> ;
+                                                   rdfs:label "Herstellungsprozess"@de ,
+                                                              "Manufacture Process"@en ;
+                                                   <http://www.w3.org/2004/02/skos/core#definition> """A process that is driven by the primary intent to transform objects
+A manufacture process is always a transformative process."""@en .
+
+
+###  http://w3id.org/pmd/ao/tto/MaterialDesignation
+<http://w3id.org/pmd/ao/tto/MaterialDesignation> rdf:type owl:Class ;
+                                                  rdfs:subClassOf <http://w3id.org/pmd/ao/tto/MaterialRelated> ;
+                                                  rdfs:label "Material Designation"@en ,
+                                                             "Materialbezeichnung"@de ;
+                                                  <http://www.w3.org/2004/02/skos/core#definition> """It is a name or identifier of a material type. It designates a material. 
+E.g. \"steel\", \"aluminium\", \"wood\", \"plastic\", \"rubber\".""" ;
+                                                  <http://www.w3.org/ns/prov#editorialNote> "former \"Material\" : \"It is a substance or mixture of substances that constitutes an object. represented by the sum of material properties and material structure\"" .
+
+
+###  http://w3id.org/pmd/ao/tto/MaterialProperty
+<http://w3id.org/pmd/ao/tto/MaterialProperty> rdf:type owl:Class ;
+                                               rdfs:subClassOf <http://w3id.org/pmd/ao/tto/MaterialRelated> ;
+                                               rdfs:label "Material Property"@en ,
+                                                          "Materialeigenschaft"@de ;
+                                               <http://www.w3.org/2004/02/skos/core#definition> "A materials property is an intensive property of a material, i.e., a physical property that does not depend on the amount of the material. These quantitative properties may be used as a metric by which the benefits of one material versus another can be compared, thereby aiding in materials selection."@en ,
+                                                                                                "Eine Materialeigenschaft ist eine intensive Eigenschaft eines Materials, d. h. eine physikalische Eigenschaft, die nicht von der Menge des Materials abhängt. Diese quantitativen Eigenschaften können als Maßstab verwendet werden, um die Vorteile eines Materials mit denen eines anderen zu vergleichen und so die Materialauswahl zu erleichtern."@de ;
+                                               <http://w3id.org/pmd/ao/tto/definitionSource> "“List of materials properties.” Wikipedia The Free Encyclopedia, http://en.wikipedia.org/wiki/List_of_materials_properties. Accessed 13 Jan. 2023."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/MaterialQuality
+<http://w3id.org/pmd/ao/tto/MaterialQuality> rdf:type owl:Class ;
+                                              rdfs:subClassOf <http://w3id.org/pmd/ao/tto/MaterialRelated> ;
+                                              rdfs:label "Material Quality"@en ,
+                                                         "Materialqualität"@de ;
+                                              <http://www.w3.org/2004/02/skos/core#definition> "i.e. Materialgüte"@de .
+
+
+###  http://w3id.org/pmd/ao/tto/MaterialRelated
+<http://w3id.org/pmd/ao/tto/MaterialRelated> rdf:type owl:Class ;
+                                              rdfs:subClassOf <http://w3id.org/pmd/ao/tto/ValueObject> ;
+                                              rdfs:label "Material Related"@en ,
+                                                         "Materialbezug"@de ;
+                                              <http://www.w3.org/2004/02/skos/core#definition> "Diese Klasse dient der qualitativen und quantitativen Beschreibung eines Materials, indem sie Informationen über ein Material angibt, z. B. durch die Einbeziehung von Materialeigenschaften, Materialstruktur usw."@de ,
+                                                                                               "This property is used to qualitatively and quantitatively describe a material by providing information on a material, e.g., by including material properties, material structure, etc."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/MaterialStructure
+<http://w3id.org/pmd/ao/tto/MaterialStructure> rdf:type owl:Class ;
+                                                rdfs:subClassOf <http://w3id.org/pmd/ao/tto/MaterialRelated> ;
+                                                rdfs:label "Material Structure"@en ,
+                                                           "Materialstruktur"@de ;
+                                                <http://www.w3.org/2004/02/skos/core#definition> "Die relevante Struktur von Materialien hat je nach Material eine unterschiedliche Längenskala. Die Struktur und Zusammensetzung eines Materials kann durch Mikroskopie oder Spektroskopie bestimmt werden."@de ,
+                                                                                                 "The relevant structure of materials has a different length scale depending on the material. The structure and composition of a material can be determined by microscopy or spectroscopy."@en ;
+                                                <http://w3id.org/pmd/ao/tto/definitionSource> "“Material - Classification by structure.” Wikipedia The Free Encyclopedia, http://en.wikipedia.org/wiki/Material#Classification_by_structure. Accessed 13 Jan. 2023."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/MaximumForce
+<http://w3id.org/pmd/ao/tto/MaximumForce> rdf:type owl:Class ;
+                                           rdfs:subClassOf <http://w3id.org/pmd/ao/tto/Force> ;
+                                           rdfs:label "Höchstkraft"@de ,
+                                                      "Maximum Force"@en ,
+                                                      "Symbol: F_m"@en ;
+                                           <http://www.w3.org/2004/02/skos/core#definition> """Bei Werkstoffen, die kein diskontinuierliches Fließen zeigen: größte Kraft, der die Probe während des Versuchs standhält
+
+Bei Werkstoffen, die ein diskontinuierliches Fließen zeigen: größte Kraft, der die Probe während des Versuchs nach dem Beginn der Verfestigung standhält
+
+Anmerkung: Für Werkstoffe, die ein diskontinuierliches Fließen zeigen, aber keine Verfestigung erzielt werden kann, ist die Höchstkraft nicht definiert
+."""@de ,
+                                                                                            """For materials displaying no discontinuous yielding: highest force that the test piece withstands during the test
+
+For materials displaying discontinuous yielding: highest force that the test piece withstands during the test after the beginning of work-hardening
+
+Note: For materials which display discontinuous yielding, but where no work-hardening can be established, the maximum force is not defined."""@en ;
+                                           <http://w3id.org/pmd/ao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/Measurement
+<http://w3id.org/pmd/ao/tto/Measurement> rdf:type owl:Class ;
+                                          rdfs:subClassOf <http://w3id.org/pmd/ao/tto/ValueScope> ;
+                                          owl:disjointWith <http://w3id.org/pmd/ao/tto/SetPoint> ;
+                                          rdfs:label "Measurement"@en ,
+                                                     "Messwert"@de ;
+                                          <http://www.w3.org/2004/02/skos/core#definition> "Measurement is the quantification of attributes of an object or event, which can be used to compare with other objects or events."@en ;
+                                          <http://w3id.org/pmd/ao/tto/definitionSource> "http://en.wikipedia.org/wiki/Measurement"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/MeasuringDevice
+<http://w3id.org/pmd/ao/tto/MeasuringDevice> rdf:type owl:Class ;
+                                              rdfs:subClassOf <http://w3id.org/pmd/ao/tto/ProcessingNode> ;
+                                              rdfs:label "Measuring Device"@en ,
+                                                         "Messgerät"@de ;
+                                              <http://www.w3.org/2004/02/skos/core#definition> "A process node capable of determining a specific quality." .
+
+
+###  http://w3id.org/pmd/ao/tto/MeasuringProcess
+<http://w3id.org/pmd/ao/tto/MeasuringProcess> rdf:type owl:Class ;
+                                               rdfs:subClassOf <http://w3id.org/pmd/ao/tto/AnalysingProcess> ;
+                                               rdfs:label "Measuring Process"@en ,
+                                                          "Messprozess"@de ;
+                                               <http://www.w3.org/2004/02/skos/core#definition> "A measurement process acquires data (usually expressed in numbers) by using tools."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/Mechanical
+<http://w3id.org/pmd/ao/tto/Mechanical> rdf:type owl:Class ;
+                                         rdfs:subClassOf <http://w3id.org/pmd/ao/tto/MaterialProperty> ;
+                                         rdfs:label "Mechanical"@en ,
+                                                    "Mechanisch"@de ;
+                                         <http://www.w3.org/2004/02/skos/core#definition> "Mechanical is relating to, governed by, or in accordance with the principles of mechanics. Here specifically to the mechanical properties of a material."@en ,
+                                                                                          "Mechanisch bedeutet, sich auf die Prinzipien der Mechanik zu beziehen, von ihnen beherrscht zu werden oder sie zu befolgen. Hier speziell auf die mechanischen Eigenschaften eines Materials."@de ;
+                                         <http://w3id.org/pmd/ao/tto/definitionSource> "“Mechanical.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/mechanical. Accessed 13 Jan. 2023."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/MechanicalTestingProcess
+<http://w3id.org/pmd/ao/tto/MechanicalTestingProcess> rdf:type owl:Class ;
+                                                       rdfs:subClassOf <http://w3id.org/pmd/ao/tto/AnalysingProcess> ;
+                                                       rdfs:label "Mechanical Testing Process"@en ,
+                                                                  "Mechanischer Testprozess"@de ;
+                                                       <http://www.w3.org/2004/02/skos/core#definition> "Determinization of a mechanical property."@en ;
+                                                       <http://w3id.org/pmd/ao/tto/definitionSource> "“Mechanical test.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/mechanical%20test. Accessed 24 Nov. 2022."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/Medium
+<http://w3id.org/pmd/ao/tto/Medium> rdf:type owl:Class ;
+                                     rdfs:subClassOf <http://w3id.org/pmd/ao/tto/Object> ;
+                                     rdfs:label "Medium"@de ,
+                                                "Medium"@en ;
+                                     <http://www.w3.org/2004/02/skos/core#definition> "Substance that surrounds an object inside the system boundaries of a process node."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/Metadata
+<http://w3id.org/pmd/ao/tto/Metadata> rdf:type owl:Class ;
+                                       rdfs:subClassOf <http://w3id.org/pmd/ao/tto/DataScope> ,
+                                                       <http://w3id.org/pmd/ao/tto/ValueObject> ;
+                                       owl:disjointWith <http://w3id.org/pmd/ao/tto/PrimaryData> ,
+                                                        <http://w3id.org/pmd/ao/tto/SecondaryData> ;
+                                       rdfs:label "Metadata"@en ,
+                                                  "Metadaten"@de ;
+                                       <http://www.w3.org/2004/02/skos/core#definition> "Attributes and additional data (provenance) concerning the factory, laboratory, the process system and the objects which allow the evaluation of the quality / reliability of the measurements and a systematic search task of a database."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/MetallicBond
+<http://w3id.org/pmd/ao/tto/MetallicBond> rdf:type owl:Class ;
+                                           rdfs:subClassOf <http://w3id.org/pmd/ao/tto/BondingType> ;
+                                           rdfs:label "Metallbindung"@de ,
+                                                      "Metallic Bond"@en ;
+                                           <http://www.w3.org/2004/02/skos/core#definition> "Metallic bond is the chemical bond typical of the metallic state and characterized by mobile valence electrons that hold the atoms together usually in crystal lattices and are responsible for the good electrical and heat conductivity of metals."@en ,
+                                                                                            "Metallische Bindung ist die für den metallischen Zustand typische chemische Bindung, die durch bewegliche Valenzelektronen gekennzeichnet ist, die die Atome in der Regel in Kristallgittern zusammenhalten und für die gute elektrische und Wärmeleitfähigkeit von Metallen verantwortlich sind."@de ;
+                                           <http://w3id.org/pmd/ao/tto/definitionSource> "\"Metallic bond.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/metallic%20bond. Accessed 13 Jan. 2023."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/Method
+<http://w3id.org/pmd/ao/tto/Method> rdf:type owl:Class ;
+                                     rdfs:subClassOf <http://w3id.org/pmd/ao/tto/ValueObject> ;
+                                     owl:disjointWith <http://w3id.org/pmd/ao/tto/Process> ;
+                                     rdfs:label "Method"@en ,
+                                                "Methode"@de ;
+                                     <http://www.w3.org/2004/02/skos/core#definition> "A way, technique, or process of or for doing something"@en ;
+                                     <http://w3id.org/pmd/ao/tto/definitionSource> "“Method.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/method. Accessed 5 Dec. 2022."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/MicrometerGauge
+<http://w3id.org/pmd/ao/tto/MicrometerGauge> rdf:type owl:Class ;
+                                              rdfs:subClassOf <http://w3id.org/pmd/ao/tto/MeasuringDevice> ;
+                                              rdfs:label "Bügelmessschraube"@de ,
+                                                         "Micrometer Gauge"@en ;
+                                              <http://www.w3.org/2004/02/skos/core#definition> "Diese Entität beschreibt ein Werkzeug zur Durchführung präziser Messungen mit einer Spindel, die durch eine Feingewindeschraube bewegt wird."@de ,
+                                                                                               "This entity describes a tool for making precise measurements having a spindle moved by a finely threaded screw."@en ;
+                                              <http://w3id.org/pmd/ao/tto/definitionSource> "http://www.merriam-webster.com/dictionary/micrometer%20caliper"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/ModulusOfElasticity
+<http://w3id.org/pmd/ao/tto/ModulusOfElasticity> rdf:type owl:Class ;
+                                                  rdfs:subClassOf <http://w3id.org/pmd/ao/tto/ValueObject> ;
+                                                  rdfs:label "Elastizitätsmodul"@de ,
+                                                             "Modulus Of Elasticity"@en ;
+                                                  <http://www.w3.org/2004/02/skos/core#definition> """Quotient der Änderung der Spannung ΔR und Änderung der prozentualen Dehnung Δe in dem untersuchten Bereich multipliziert mit 100 % 
+
+Anmerkung: Es wird empfohlen, den Wert in GPa, gerundet auf 0,1 GPa, und nach ISO 80000-1 anzugeben."""@de ,
+                                                                                                   "Symbol: E"@en ,
+                                                                                                   """quotient of change of stress ΔR and change of percentage extension Δe in the range of evaluation, multiplied by 100 %
+
+Note: It is recommended to report the value in GPa rounded to the nearest 0.1 GPa and according to ISO 80000-1."""@en ;
+                                                  <http://w3id.org/pmd/ao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/MountingProcess
+<http://w3id.org/pmd/ao/tto/MountingProcess> rdf:type owl:Class ;
+                                              rdfs:subClassOf <http://w3id.org/pmd/ao/tto/AssemblingProcess> ;
+                                              owl:disjointWith <http://w3id.org/pmd/ao/tto/TemperatureChangingProcess> ;
+                                              rdfs:label "Montageprozess"@de ,
+                                                         "Mounting Process"@en ;
+                                              <http://www.w3.org/2004/02/skos/core#definition> "This property is used to describe the process of installing, assembling oder otherwise incorporating a test piece or specimen into a test machine. This may include the usage of other process nodes (e.g. grips)."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/NodeInfo
+<http://w3id.org/pmd/ao/tto/NodeInfo> rdf:type owl:Class ;
+                                       rdfs:subClassOf <http://w3id.org/pmd/ao/tto/ValueObject> ;
+                                       rdfs:label "Knoteninformation"@de ,
+                                                  "Node Info"@en ;
+                                       <http://www.w3.org/2004/02/skos/core#definition> "Descriptive values to specify a process node."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/NodeModel
+<http://w3id.org/pmd/ao/tto/NodeModel> rdf:type owl:Class ;
+                                        rdfs:subClassOf <http://w3id.org/pmd/ao/tto/NodeInfo> ;
+                                        rdfs:label "Knotenmodell"@de ,
+                                                   "Node Model"@en ;
+                                        <http://www.w3.org/2004/02/skos/core#definition> "Process Node short description, e.g. \"Vacuum Furnace\""@en .
+
+
+###  http://w3id.org/pmd/ao/tto/NodeName
+<http://w3id.org/pmd/ao/tto/NodeName> rdf:type owl:Class ;
+                                       rdfs:subClassOf <http://w3id.org/pmd/ao/tto/NodeInfo> ;
+                                       rdfs:label "Knotenname"@de ,
+                                                  "Node Name"@en ;
+                                       <http://www.w3.org/2004/02/skos/core#definition> "A human-generated identifier associated with a discernible, tangible or simulated entity intended to be unique in a given scope"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/NodeSerialNumber
+<http://w3id.org/pmd/ao/tto/NodeSerialNumber> rdf:type owl:Class ;
+                                               rdfs:subClassOf <http://w3id.org/pmd/ao/tto/NodeInfo> ;
+                                               rdfs:label "Knoten-Seriennummer"@de ,
+                                                          "Node Serial Number"@en ;
+                                               <http://www.w3.org/2004/02/skos/core#definition> "A unique identifier of a process node, typically provided by the manufacturer (manufacturer serial number,  s/n)."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/NodeType
+<http://w3id.org/pmd/ao/tto/NodeType> rdf:type owl:Class ;
+                                       rdfs:subClassOf <http://w3id.org/pmd/ao/tto/NodeInfo> ;
+                                       rdfs:label "Knotentyp"@de ,
+                                                  "Node Type"@en ;
+                                       <http://www.w3.org/2004/02/skos/core#definition> "Process Node typename, e.g. \"ProTherm500\""@en .
+
+
+###  http://w3id.org/pmd/ao/tto/NodeVersion
+<http://w3id.org/pmd/ao/tto/NodeVersion> rdf:type owl:Class ;
+                                          rdfs:subClassOf <http://w3id.org/pmd/ao/tto/NodeInfo> ;
+                                          rdfs:label "Knotenversion"@de ,
+                                                     "Node Version"@en ;
+                                          <http://www.w3.org/2004/02/skos/core#definition> "Process Node Version Number, e.g. \"2.24\""@en .
+
+
+###  http://w3id.org/pmd/ao/tto/NonTransformativeAnalysisProcess
+<http://w3id.org/pmd/ao/tto/NonTransformativeAnalysisProcess> rdf:type owl:Class ;
+                                                               rdfs:subClassOf <http://w3id.org/pmd/ao/tto/AnalysingProcess> ;
+                                                               owl:disjointWith <http://w3id.org/pmd/ao/tto/TransformativeAnalysisProcess> ;
+                                                               rdfs:label "Nicht-transformativer Analyseprozess"@de ,
+                                                                          "Non Transformative Analysis Process"@en ;
+                                                               <http://www.w3.org/2004/02/skos/core#definition> "An analysis process that is also a non-transformative process"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/Norm
+<http://w3id.org/pmd/ao/tto/Norm> rdf:type owl:Class ;
+                                   rdfs:subClassOf <http://w3id.org/pmd/ao/tto/Method> ;
+                                   rdfs:label "Norm"@de ,
+                                              "Norm"@en ;
+                                   <http://www.w3.org/2004/02/skos/core#definition> "An authoritative standard."@en ;
+                                   <http://www.w3.org/2004/02/skos/core#example> "Technical standard issued by the German Institute for Standardisation Registered Association (Deutsches Institut für Normung e.V. - DIN)"@en ;
+                                   <http://w3id.org/pmd/ao/tto/definitionSource> "“Norm.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/norm. Accessed 24 Nov. 2022."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/Note
+<http://w3id.org/pmd/ao/tto/Note> rdf:type owl:Class ;
+                                   rdfs:subClassOf <http://w3id.org/pmd/ao/tto/ValueObject> ;
+                                   rdfs:label "Bemerkung"@de ,
+                                              "Note"@en ,
+                                              "Notiz"@de ;
+                                   <http://www.w3.org/2004/02/skos/core#definition> "Additional information & knowledge for and by humans. Not expected to be parsable"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/Object
+<http://w3id.org/pmd/ao/tto/Object> rdf:type owl:Class ;
+                                     rdfs:subClassOf <http://www.w3.org/ns/prov#Entity> ;
+                                     rdfs:label "Object"@en ,
+                                                "Objekt"@de ;
+                                     <http://www.w3.org/2004/02/skos/core#definition> "A discernable, tangible or simulated entity that is processed in a process by a process node."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/Operator
+<http://w3id.org/pmd/ao/tto/Operator> rdf:type owl:Class ;
+                                       rdfs:subClassOf <http://www.w3.org/ns/prov#Person> ;
+                                       rdfs:label "Operator"@de ,
+                                                  "Operator"@en ;
+                                       <http://www.w3.org/2004/02/skos/core#definition> "A person that operates a machine or device."@en ;
+                                       <http://w3id.org/pmd/ao/tto/definitionSource> "“Operator.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/operator. Accessed 24 Nov. 2022."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/Optical
+<http://w3id.org/pmd/ao/tto/Optical> rdf:type owl:Class ;
+                                      rdfs:subClassOf <http://w3id.org/pmd/ao/tto/MaterialProperty> ;
+                                      rdfs:label "Optical"@en ,
+                                                 "Optisch"@de ;
+                                      <http://www.w3.org/2004/02/skos/core#definition> "Optical is relating to the science of optics. Here specifically to the optical properties of a material."@en ,
+                                                                                       "Optisch bezieht sich auf die Wissenschaft der Optik. Hier speziell auf die optischen Eigenschaften eines Materials."@de ;
+                                      <http://w3id.org/pmd/ao/tto/definitionSource> "“Optical.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/optical. Accessed 13 Jan. 2023."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/OriginalDiameter
+<http://w3id.org/pmd/ao/tto/OriginalDiameter> rdf:type owl:Class ;
+                                               rdfs:subClassOf <http://w3id.org/pmd/ao/tto/Diameter> ;
+                                               rdfs:label "Anfangs-Probendurchmesser"@de ,
+                                                          "Original Diameter"@en ;
+                                               <http://www.w3.org/2004/02/skos/core#definition> "Die Länge einer geraden Linie durch den Mittelpunkt eines Objekts (Prüfkörpers), die vor einer Prüfung gemessen wird."@de ,
+                                                                                                "The length of a straight line through the center of an object (test piece) as measured before a test."@en ;
+                                               <http://w3id.org/pmd/ao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/OriginalGaugeLength
+<http://w3id.org/pmd/ao/tto/OriginalGaugeLength> rdf:type owl:Class ;
+                                                  rdfs:subClassOf <http://w3id.org/pmd/ao/tto/GaugeLength> ;
+                                                  rdfs:label "Anfangsmesslänge"@de ,
+                                                             "Original Gauge Length"@en ;
+                                                  <http://www.w3.org/2004/02/skos/core#definition> "Länge zwischen den Marken zur Kennzeichnung der Messlänge auf der Probe, die vor dem Versuch bei Raumtemperatur gemessen wird"@de ,
+                                                                                                   "Symbol: L_o"@en ,
+                                                                                                   "length between gauge length marks on the test piece measured at room temperature before the test"@en ;
+                                                  <http://w3id.org/pmd/ao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/OriginalThickness
+<http://w3id.org/pmd/ao/tto/OriginalThickness> rdf:type owl:Class ;
+                                                rdfs:subClassOf <http://w3id.org/pmd/ao/tto/Length> ;
+                                                rdfs:label "Anfangs-Dicke"@de ,
+                                                           "Original Thickness"@en ;
+                                                <http://www.w3.org/2004/02/skos/core#definition> "Diese Eigenschaft beschreibt die gemessene Dimension in einer Richtung eines Prüfstücks, wie sie vor der Prüfung gemessen wurde."@de ,
+                                                                                                 "This property describes the measured dimension in one direction of a test piece, as measured before the test."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/OriginalWidth
+<http://w3id.org/pmd/ao/tto/OriginalWidth> rdf:type owl:Class ;
+                                            rdfs:subClassOf <http://w3id.org/pmd/ao/tto/Width> ;
+                                            rdfs:label "Anfangs-Breite"@de ,
+                                                       "Original Width"@en ;
+                                            <http://www.w3.org/2004/02/skos/core#definition> "Diese Eigenschaft beschreibt eine horizontale Messung eines Objekts (Prüfkörpers) im rechten Winkel zur Länge des Objekts (Prüfkörpers), wie sie vor einer Prüfung gemessen wird."@de ,
+                                                                                             "This property describes a horizontal measurement of an object (test piece) taken at right angles to the length of the object (test piece), as measured before a test."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/ParallelLength
+<http://w3id.org/pmd/ao/tto/ParallelLength> rdf:type owl:Class ;
+                                             rdfs:subClassOf <http://w3id.org/pmd/ao/tto/Length> ;
+                                             rdfs:label "Parallel Length"@en ,
+                                                        "Parallele Länge"@de ;
+                                             <http://www.w3.org/2004/02/skos/core#definition> """Länge des parallelen reduzierten Querschnitts der Probe
+
+Anmerkung: Bei unbearbeiteten Proben tritt an die Stelle der parallelen Länge der Abstand zwischen den Einspannungen."""@de ,
+                                                                                              "Symbol: L_c"@en ,
+                                                                                              """length of the parallel reduced section of the test piece
+
+Note: The concept of parallel length is replaced by the concept of distance between grips for unmachined test pieces."""@en ;
+                                             <http://w3id.org/pmd/ao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/PercentageElongation
+<http://w3id.org/pmd/ao/tto/PercentageElongation> rdf:type owl:Class ;
+                                                   owl:equivalentClass [ rdf:type owl:Restriction ;
+                                                                         owl:onProperty <http://w3id.org/pmd/ao/tto/relatesTo> ;
+                                                                         owl:someValuesFrom <http://w3id.org/pmd/ao/tto/OriginalGaugeLength>
+                                                                       ] ;
+                                                   rdfs:subClassOf <http://w3id.org/pmd/ao/tto/Elongation> ;
+                                                   rdfs:label "Dehnung"@de ,
+                                                              "Percentage Elongation"@en ;
+                                                   <http://www.w3.org/2004/02/skos/core#definition> "Verlängerung, angegeben in Prozent, bezogen auf die Anfangsmesslänge"@de ,
+                                                                                                    "elongation expressed as a percentage of the original gauge length"@en ;
+                                                   <http://w3id.org/pmd/ao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/PercentageElongationAfterFracture
+<http://w3id.org/pmd/ao/tto/PercentageElongationAfterFracture> rdf:type owl:Class ;
+                                                                owl:equivalentClass [ rdf:type owl:Restriction ;
+                                                                                      owl:onProperty <http://w3id.org/pmd/ao/tto/relatesTo> ;
+                                                                                      owl:someValuesFrom <http://w3id.org/pmd/ao/tto/OriginalGaugeLength>
+                                                                                    ] ;
+                                                                rdfs:subClassOf <http://w3id.org/pmd/ao/tto/Elongation> ;
+                                                                rdfs:label "Bruchdehnung"@de ,
+                                                                           "Percentage Elongation After Fracture"@en ;
+                                                                <http://www.w3.org/2004/02/skos/core#definition> "Symbol: A"@en ,
+                                                                                                                 "bleibende Verlängerung der Messlänge nach dem Bruch (L_u − L_o), angegeben in Prozent, bezogen auf die Anfangsmesslänge"@de ,
+                                                                                                                 "permanent elongation of the gauge length after fracture (L_u − L_o), expressed as a percentage of the original gauge length"@en ;
+                                                                <http://w3id.org/pmd/ao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/PercentageExtension
+<http://w3id.org/pmd/ao/tto/PercentageExtension> rdf:type owl:Class ;
+                                                  owl:equivalentClass [ rdf:type owl:Restriction ;
+                                                                        owl:onProperty <http://w3id.org/pmd/ao/tto/relatesTo> ;
+                                                                        owl:someValuesFrom <http://w3id.org/pmd/ao/tto/ExtensometerGaugeLength>
+                                                                      ] ;
+                                                  rdfs:subClassOf <http://w3id.org/pmd/ao/tto/Extension> ;
+                                                  rdfs:label "Extensometer-Dehnung"@de ,
+                                                             "Percentage Extension"@en ;
+                                                  <http://www.w3.org/2004/02/skos/core#definition> "Synonym: (engineering) strain"@en ,
+                                                                                                   "Synonym: technische Dehnung"@de ,
+                                                                                                   """extension expressed as a percentage of the extensometer gauge length
+
+Note: The percentage extension is commonly called engineering strain."""@en ,
+                                                                                                   """in Prozent angegebene Verlängerung der Extensometer-Messlänge
+
+Anmerkung: Die Extensometer-Dehnung wird oftmals auch als technische Dehnung bezeichnet."""@de ;
+                                                  <http://w3id.org/pmd/ao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/PercentagePermanentElongation
+<http://w3id.org/pmd/ao/tto/PercentagePermanentElongation> rdf:type owl:Class ;
+                                                            owl:equivalentClass [ rdf:type owl:Restriction ;
+                                                                                  owl:onProperty <http://w3id.org/pmd/ao/tto/relatesTo> ;
+                                                                                  owl:someValuesFrom <http://w3id.org/pmd/ao/tto/OriginalGaugeLength>
+                                                                                ] ;
+                                                            rdfs:subClassOf <http://w3id.org/pmd/ao/tto/Elongation> ;
+                                                            rdfs:label "Bleibende Dehnung"@de ,
+                                                                       "Percentage Permanent Elongation"@en ;
+                                                            <http://www.w3.org/2004/02/skos/core#definition> "Zunahme der Anfangsmesslänge einer Probe nach Entfernen einer festgelegten Zugspannung, angegeben in Prozent, bezogen auf die Anfangsmesslänge"@de ,
+                                                                                                             "increase in the original gauge length of a test piece after removal of a specified stress, expressed as a percentage of the original gauge length"@en ;
+                                                            <http://w3id.org/pmd/ao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/PercentagePermanentExtension
+<http://w3id.org/pmd/ao/tto/PercentagePermanentExtension> rdf:type owl:Class ;
+                                                           owl:equivalentClass [ rdf:type owl:Restriction ;
+                                                                                 owl:onProperty <http://w3id.org/pmd/ao/tto/relatesTo> ;
+                                                                                 owl:someValuesFrom <http://w3id.org/pmd/ao/tto/ExtensometerGaugeLength>
+                                                                               ] ;
+                                                           rdfs:subClassOf <http://w3id.org/pmd/ao/tto/Extension> ;
+                                                           rdfs:label "Bleibende Extensometer-Dehnung"@de ,
+                                                                      "Percentage Permanent Extension"@en ;
+                                                           <http://www.w3.org/2004/02/skos/core#definition> "Vergrößerung der Extensometer-Messlänge nach Entfernen einer festgelegten, auf die Probe aufgebrachten Zugspannung, angegeben in Prozent, bezogen auf die Extensometer-Messlänge"@de ,
+                                                                                                            "increase in the extensometer gauge length, after removal of a specified stress from the test piece, expressed as a percentage of the extensometer gauge length"@en ;
+                                                           <http://w3id.org/pmd/ao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/PercentagePlasticExtensionAtMaximumForce
+<http://w3id.org/pmd/ao/tto/PercentagePlasticExtensionAtMaximumForce> rdf:type owl:Class ;
+                                                                       owl:equivalentClass [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
+                                                                                                                    owl:onProperty <http://w3id.org/pmd/ao/tto/relatesTo> ;
+                                                                                                                    owl:someValuesFrom <http://w3id.org/pmd/ao/tto/ExtensometerGaugeLength>
+                                                                                                                  ]
+                                                                                                                  [ rdf:type owl:Restriction ;
+                                                                                                                    owl:onProperty <http://w3id.org/pmd/ao/tto/relatesTo> ;
+                                                                                                                    owl:someValuesFrom <http://w3id.org/pmd/ao/tto/MaximumForce>
+                                                                                                                  ]
+                                                                                                                ) ;
+                                                                                             rdf:type owl:Class
+                                                                                           ] ;
+                                                                       rdfs:subClassOf <http://w3id.org/pmd/ao/tto/Extension> ;
+                                                                       rdfs:label "Percentage Plastic Extension At Maximum Force"@en ,
+                                                                                  "Plastische Extensometer-Dehnung bei Höchstkraft"@de ;
+                                                                       <http://www.w3.org/2004/02/skos/core#definition> "Symbol: A_g"@en ,
+                                                                                                                        "plastic extension at maximum force, expressed as a percentage of the extensometer gauge length"@en ,
+                                                                                                                        "plastische Verlängerung der Extensometer-Messlänge bei Höchstkraft, angegeben in Prozent, bezogen auf die Extensometer-Messlänge"@de ;
+                                                                       <http://w3id.org/pmd/ao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/PercentageReductionOfArea
+<http://w3id.org/pmd/ao/tto/PercentageReductionOfArea> rdf:type owl:Class ;
+                                                        owl:equivalentClass [ rdf:type owl:Class ;
+                                                                              owl:unionOf ( [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
+                                                                                                                     owl:onProperty <http://w3id.org/pmd/ao/tto/relatesTo> ;
+                                                                                                                     owl:someValuesFrom <http://w3id.org/pmd/ao/tto/OriginalThickness>
+                                                                                                                   ]
+                                                                                                                   [ rdf:type owl:Restriction ;
+                                                                                                                     owl:onProperty <http://w3id.org/pmd/ao/tto/relatesTo> ;
+                                                                                                                     owl:someValuesFrom <http://w3id.org/pmd/ao/tto/OriginalWidth>
+                                                                                                                   ]
+                                                                                                                 ) ;
+                                                                                              rdf:type owl:Class
+                                                                                            ]
+                                                                                            [ rdf:type owl:Restriction ;
+                                                                                              owl:onProperty <http://w3id.org/pmd/ao/tto/relatesTo> ;
+                                                                                              owl:someValuesFrom <http://w3id.org/pmd/ao/tto/OriginalDiameter>
+                                                                                            ]
+                                                                                          )
+                                                                            ] ;
+                                                        rdfs:subClassOf <http://w3id.org/pmd/ao/tto/ValueObject> ;
+                                                        rdfs:label "Brucheinschnürung"@de ,
+                                                                   "Percentage Reduction Of Area"@en ;
+                                                        <http://www.w3.org/2004/02/skos/core#definition> "Symbol: Z"@en ,
+                                                                                                         "größte während des Versuchs aufgetretene Änderung des Querschnitts (S_o − S_u), angegeben in Prozent, bezogen auf den Anfangsquerschnitt S_o"@de ,
+                                                                                                         "maximum change in cross-sectional area which has occurred during the test (S_o − S_u), expressed as a percentage of the original cross-sectional area, S_o"@en ;
+                                                        <http://w3id.org/pmd/ao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/PercentageTotalExtensionAtFracture
+<http://w3id.org/pmd/ao/tto/PercentageTotalExtensionAtFracture> rdf:type owl:Class ;
+                                                                 owl:equivalentClass [ rdf:type owl:Restriction ;
+                                                                                       owl:onProperty <http://w3id.org/pmd/ao/tto/relatesTo> ;
+                                                                                       owl:someValuesFrom <http://w3id.org/pmd/ao/tto/ExtensometerGaugeLength>
+                                                                                     ] ;
+                                                                 rdfs:subClassOf <http://w3id.org/pmd/ao/tto/Extension> ;
+                                                                 rdfs:label "Gesamte Extensometer-Dehnung beim Bruch"@de ,
+                                                                            "Percentage Total Extension At Fracture"@en ;
+                                                                 <http://www.w3.org/2004/02/skos/core#definition> "Symbol: A_t"@en ,
+                                                                                                                  "gesamte Verlängerung (elastische plus plastische Verlängerung) der Extensometer-Messlänge beim Bruch, angegeben in Prozent, bezogen auf die Extensometer-Messlänge"@de ,
+                                                                                                                  "total extension (elastic extension plus plastic extension) at the moment of fracture, expressed as a percentage of the extensometer gauge length"@en ;
+                                                                 <http://w3id.org/pmd/ao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/PercentageTotalExtensionAtMaximumForce
+<http://w3id.org/pmd/ao/tto/PercentageTotalExtensionAtMaximumForce> rdf:type owl:Class ;
+                                                                     owl:equivalentClass [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
+                                                                                                                  owl:onProperty <http://w3id.org/pmd/ao/tto/relatesTo> ;
+                                                                                                                  owl:someValuesFrom <http://w3id.org/pmd/ao/tto/ExtensometerGaugeLength>
+                                                                                                                ]
+                                                                                                                [ rdf:type owl:Restriction ;
+                                                                                                                  owl:onProperty <http://w3id.org/pmd/ao/tto/relatesTo> ;
+                                                                                                                  owl:someValuesFrom <http://w3id.org/pmd/ao/tto/MaximumForce>
+                                                                                                                ]
+                                                                                                              ) ;
+                                                                                           rdf:type owl:Class
+                                                                                         ] ;
+                                                                     rdfs:subClassOf <http://w3id.org/pmd/ao/tto/Extension> ;
+                                                                     rdfs:label "Gesamte Extensometer-Dehnung bei Höchstkraft"@de ,
+                                                                                "Percentage Total Extension At Maximum Force"@en ;
+                                                                     <http://www.w3.org/2004/02/skos/core#definition> "Symbol: A_gt"@en ,
+                                                                                                                      "gesamte Verlängerung (elastische plus plastische Verlängerung) der Extensometer-Messlänge bei Höchstkraft, angegeben in Prozent, bezogen auf die Extensometer-Messlänge"@de ,
+                                                                                                                      "total extension (elastic extension plus plastic extension) at maximum force, expressed as a percentage of the extensometer gauge length"@en ;
+                                                                     <http://w3id.org/pmd/ao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/PercentageYieldPointExtension
+<http://w3id.org/pmd/ao/tto/PercentageYieldPointExtension> rdf:type owl:Class ;
+                                                            rdfs:subClassOf <http://w3id.org/pmd/ao/tto/Extension> ;
+                                                            rdfs:label "Percentage Yield Point Extension"@en ,
+                                                                       "Streckgrenzen-Extensometer-Dehnung"@de ;
+                                                            <http://www.w3.org/2004/02/skos/core#definition> "Bei Werkstoffen, die ein diskontinuierliches Fließen zeigen: Verlängerung der Extensometer-Messlänge zwischen dem Beginn örtlichen Fließens und dem Einsetzen gleichmäßiger Verfestigung, angegeben in Prozent, bezogen auf die Extensometer-Messlänge"@de ,
+                                                                                                             "For discontinuous yielding materials: extension between the start of yielding and the start of uniform work-hardening, expressed as a percentage of the extensometer gauge length"@en ,
+                                                                                                             "Symbol: A_e"@en ;
+                                                            <http://w3id.org/pmd/ao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/Perimeter
+<http://w3id.org/pmd/ao/tto/Perimeter> rdf:type owl:Class ;
+                                        rdfs:subClassOf <http://w3id.org/pmd/ao/tto/ValueObject> ;
+                                        rdfs:label "Perimeter"@en ,
+                                                   "Umfang"@de ;
+                                        <http://www.w3.org/2004/02/skos/core#definition> "Der Durchmesser einer zweidimensionalen Form."@de ,
+                                                                                         "The perimeter of a two-dimensional shape is defined as the path or boundary that encloses the shape."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/Precision
+<http://w3id.org/pmd/ao/tto/Precision> rdf:type owl:Class ;
+                                        rdfs:subClassOf <http://w3id.org/pmd/ao/tto/ValueObject> ;
+                                        rdfs:label "Genauigkeit"@de ,
+                                                   "Precision"@en ;
+                                        <http://www.w3.org/2004/02/skos/core#definition> "Der Grad der Verfeinerung, mit dem eine Operation durchgeführt oder eine Messung angegeben wird."@de ,
+                                                                                         "The degree of refinement with which an operation is performed or a measurement stated."@en ;
+                                        <http://w3id.org/pmd/ao/tto/definitionSource> "“Precision.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/precision. Accessed 13 Jan. 2023."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/PrimaryData
+<http://w3id.org/pmd/ao/tto/PrimaryData> rdf:type owl:Class ;
+                                          rdfs:subClassOf <http://w3id.org/pmd/ao/tto/DataScope> ;
+                                          owl:disjointWith <http://w3id.org/pmd/ao/tto/SecondaryData> ;
+                                          rdfs:label "Primary Data"@en ,
+                                                     "Primärdaten"@de ;
+                                          <http://www.w3.org/2004/02/skos/core#definition> "Data acquired before / after a process either refering to the geometry of the object (e.g. ao, bo, do, au, bu, du, Lu) or as a register of the complete setup (e.g. sketches, photos or videos)"@en ,
+                                                                                           "Data directly acquired during a process by sensors (time, force, length, temperature)"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/Process
+<http://w3id.org/pmd/ao/tto/Process> rdf:type owl:Class ;
+                                      rdfs:subClassOf <http://www.w3.org/ns/prov#Activity> ;
+                                      rdfs:label "Process"@en ,
+                                                 "Prozess"@de ;
+                                      <http://www.w3.org/2004/02/skos/core#definition> """A series of actions or operations conducing to an end
+In PMD, a process is conducted via process nodes and has a discernable duration as part of a workflow. A process consumes objects and parameters. A process potentially generates new objects and measurements. A process is either a transformative process or a non-transformative process with respect to objects processed via a process node. There are primarily two types of distinguishable processes: manufacture process, analysis process. A process is a series of operations that are subordinate processes."""@en .
+
+
+###  http://w3id.org/pmd/ao/tto/ProcessDescription
+<http://w3id.org/pmd/ao/tto/ProcessDescription> rdf:type owl:Class ;
+                                                 owl:equivalentClass [ owl:intersectionOf ( <http://w3id.org/pmd/ao/tto/Description>
+                                                                                            [ rdf:type owl:Restriction ;
+                                                                                              owl:onProperty <http://w3id.org/pmd/ao/tto/isCharacteristicOf> ;
+                                                                                              owl:someValuesFrom <http://w3id.org/pmd/ao/tto/Process>
+                                                                                            ]
+                                                                                          ) ;
+                                                                       rdf:type owl:Class
+                                                                     ] ;
+                                                 rdfs:subClassOf <http://w3id.org/pmd/ao/tto/Description> ;
+                                                 rdfs:label "Process Description"@en ,
+                                                            "Prozessbeschreibung"@de ;
+                                                 <http://www.w3.org/2004/02/skos/core#definition> "A descriptive text qualifying the nature of a process instance used as an identifier that is not strictly intended to be unique, e.g. \"1050°C30 840°C10/ÖL\"."@en ,
+                                                                                                  "A human readable order of steps. Might include additional information that likes sketches and notes."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/ProcessDuration
+<http://w3id.org/pmd/ao/tto/ProcessDuration> rdf:type owl:Class ;
+                                              rdfs:subClassOf <http://w3id.org/pmd/ao/tto/ValueObject> ;
+                                              rdfs:label "Process Duration"@en ,
+                                                         "Prozessdauer"@de ;
+                                              <http://www.w3.org/2004/02/skos/core#definition> "A length of an interval of time in which a process is conducted."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/ProcessIdentifier
+<http://w3id.org/pmd/ao/tto/ProcessIdentifier> rdf:type owl:Class ;
+                                                owl:equivalentClass [ owl:intersectionOf ( <http://w3id.org/pmd/ao/tto/Identifier>
+                                                                                           [ rdf:type owl:Restriction ;
+                                                                                             owl:onProperty <http://w3id.org/pmd/ao/tto/isCharacteristicOf> ;
+                                                                                             owl:someValuesFrom <http://w3id.org/pmd/ao/tto/Process>
+                                                                                           ]
+                                                                                         ) ;
+                                                                      rdf:type owl:Class
+                                                                    ] ;
+                                                rdfs:subClassOf <http://w3id.org/pmd/ao/tto/Identifier> ;
+                                                rdfs:label "Process Identifier"@en ,
+                                                           "Prozessidentifikator"@de ;
+                                                <http://www.w3.org/2004/02/skos/core#definition> "A colloquial, human-generated, descriptive text qualifying the nature of a process instance used as an identifier that is not strictly intended to be unique, e.g. “1050°C30 840°C10/ÖL”."@en ,
+                                                                                                 "Ein umgangssprachlicher, von Menschen erstellter, beschreibender Text, der die Art einer Prozessinstanz qualifiziert, die als Kennung verwendet wird, die nicht unbedingt eindeutig sein muss, z.B. “1050°C30 840°C10/ÖL”."@de .
+
+
+###  http://w3id.org/pmd/ao/tto/ProcessingNode
+<http://w3id.org/pmd/ao/tto/ProcessingNode> rdf:type owl:Class ;
+                                             rdfs:subClassOf <http://www.w3.org/ns/prov#Entity> ;
+                                             rdfs:label "Processing Node"@en ,
+                                                        "Prozessknoten"@de ;
+                                             <http://www.w3.org/2004/02/skos/core#definition> "A workflow constituent that hosts tools in the form of software to facilitate, e.g. simulation, prediction, or machine learning."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/Project
+<http://w3id.org/pmd/ao/tto/Project> rdf:type owl:Class ;
+                                      rdfs:subClassOf <http://www.w3.org/ns/prov#Activity> ;
+                                      rdfs:label "Project"@en ,
+                                                 "Projekt"@de ;
+                                      <http://www.w3.org/2004/02/skos/core#definition> "A series of goal-orientated (intent) activities and interactions to achieve a specific outcome."@en ,
+                                                                                       "Eine Reihe von zielorientierten (absichtlichen) Aktivitäten und Interaktionen, um ein bestimmtes Ergebnis zu erzielen."@de .
+
+
+###  http://w3id.org/pmd/ao/tto/ProjectIdentifier
+<http://w3id.org/pmd/ao/tto/ProjectIdentifier> rdf:type owl:Class ;
+                                                owl:equivalentClass [ owl:intersectionOf ( <http://w3id.org/pmd/ao/tto/Identifier>
+                                                                                           [ rdf:type owl:Restriction ;
+                                                                                             owl:onProperty <http://w3id.org/pmd/ao/tto/isCharacteristicOf> ;
+                                                                                             owl:someValuesFrom <http://w3id.org/pmd/ao/tto/Project>
+                                                                                           ]
+                                                                                         ) ;
+                                                                      rdf:type owl:Class
+                                                                    ] ;
+                                                rdfs:subClassOf <http://w3id.org/pmd/ao/tto/Identifier> ;
+                                                rdfs:label "Project Identifier"@en ,
+                                                           "Projektidentifikator"@de ;
+                                                <http://www.w3.org/2004/02/skos/core#definition> "A colloquial, human-generated, descriptive text qualifying the nature of a project."@en ,
+                                                                                                 "Ein umgangssprachlicher, von Menschen erstellter, beschreibender Text, der die Art eines Projekts qualifiziert."@de .
+
+
+###  http://w3id.org/pmd/ao/tto/ProofStrength
+<http://w3id.org/pmd/ao/tto/ProofStrength> rdf:type owl:Class ;
+                                            rdfs:subClassOf <http://w3id.org/pmd/ao/tto/Extension> ;
+                                            rdfs:label "Dehngrenze"@de ,
+                                                       "Proof Strength"@en ;
+                                            <http://www.w3.org/2004/02/skos/core#definition> "Spannung, bei der ein bestimmter Dehnungswert gleich einem bestimmten Prozentsatz der Messlänge des Dehnungsmessers ist"@de ,
+                                                                                             "stress at which the a specific extension value is equal to a specified percentage of the extensometer gauge length"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/ProofStrengthPlasticExtension
+<http://w3id.org/pmd/ao/tto/ProofStrengthPlasticExtension> rdf:type owl:Class ;
+                                                            rdfs:subClassOf <http://w3id.org/pmd/ao/tto/ProofStrength> ;
+                                                            rdfs:label "Dehngrenze bei plastischer Extensometer-Dehnung"@de ,
+                                                                       "Proof Strength Plastic Extension"@en ;
+                                                            <http://www.w3.org/2004/02/skos/core#definition> """Spannung, bei der die plastische Extensometer-Dehnung einem vorgegebenen Prozentanteil der Extensometer-Messlänge entspricht
+
+Anmerkung: Der Index wird durch den Zahlenwert ergänzt, der den vorgegebenen Zahlenwert der plastischen Extensometer-Dehnung in Prozent angibt, z. B. R_p_0,2."""@de ,
+                                                                                                             "Symbol: R_p"@en ,
+                                                                                                             """stress at which the plastic extension is equal to a specified percentage of the extensometer gauge length
+
+Note: A suffix is added to the subscript to indicate the prescribed percentage, e.g. R_p_0.2.
+
+Source: ISO 6892-1:2019"""@en ;
+                                                            <http://w3id.org/pmd/ao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/ProofStrengthTotalExtension
+<http://w3id.org/pmd/ao/tto/ProofStrengthTotalExtension> rdf:type owl:Class ;
+                                                          owl:equivalentClass [ rdf:type owl:Restriction ;
+                                                                                owl:onProperty <http://w3id.org/pmd/ao/tto/relatesTo> ;
+                                                                                owl:someValuesFrom <http://w3id.org/pmd/ao/tto/PercentageExtension>
+                                                                              ] ;
+                                                          rdfs:subClassOf <http://w3id.org/pmd/ao/tto/ProofStrength> ;
+                                                          rdfs:label "Dehngrenze bei gesamter Extensometer-Dehnung"@de ,
+                                                                     "Proof Strength Total Extension"@en ;
+                                                          <http://www.w3.org/2004/02/skos/core#definition> """Spannung, bei der die gesamte Extensometer-Dehnung (elastische und plastische Extensometer-Dehnung) einem vorgegebenen Prozentanteil der Extensometer-Messlänge entspricht
+
+Anmerkung: Der Index wird durch den Zahlenwert ergänzt, der den vorgegebenen Zahlenwert der gesamten Extensometer-Dehnung in Prozent angibt, z. B. R_t_0,5."""@de ,
+                                                                                                           "Symbol: R_t"@en ,
+                                                                                                           """stress at which total extension (elastic extension plus plastic extension) is equal to a specified percentage of the extensometer gauge length
+
+Note: A suffix is added to the subscript to indicate the prescribed percentage, e.g. R_t_0.5."""@en ;
+                                                          <http://w3id.org/pmd/ao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/ProvidedIdentifier
+<http://w3id.org/pmd/ao/tto/ProvidedIdentifier> rdf:type owl:Class ;
+                                                 rdfs:subClassOf <http://w3id.org/pmd/ao/tto/Identifier> ;
+                                                 rdfs:label "Bereitgestellter Identifikator"@de ,
+                                                            "Provided Identifier"@en ;
+                                                 <http://www.w3.org/2004/02/skos/core#definition> "A colloquial, human-generated desrciptor."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/QualifyingNodeAnnotation
+<http://w3id.org/pmd/ao/tto/QualifyingNodeAnnotation> rdf:type owl:Class ;
+                                                       rdfs:subClassOf <http://w3id.org/pmd/ao/tto/NodeInfo> ;
+                                                       rdfs:label "Qualifizierende Knotenannotation"@de ,
+                                                                  "Qualifying Node Annotation"@en ;
+                                                       <http://www.w3.org/2004/02/skos/core#definition> "Description for Process Node's utility, e.g. \"Rear Vacuum Furnace Oil Quenching\""@en .
+
+
+###  http://w3id.org/pmd/ao/tto/Radiological
+<http://w3id.org/pmd/ao/tto/Radiological> rdf:type owl:Class ;
+                                           rdfs:subClassOf <http://w3id.org/pmd/ao/tto/MaterialProperty> ;
+                                           rdfs:label "Radiological"@en ,
+                                                      "Radiologisch"@de ;
+                                           <http://www.w3.org/2004/02/skos/core#definition> "Radiological is relating to radiology. Here specifically to the radiological properties of a material."@en ,
+                                                                                            "Radiologisch bezieht sich auf die Radiologie. Hier speziell auf die radiologischen Eigenschaften eines Materials."@de ;
+                                           <http://w3id.org/pmd/ao/tto/definitionSource> "“Radiological.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/radiological. Accessed 13 Jan. 2023."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/Radius
+<http://w3id.org/pmd/ao/tto/Radius> rdf:type owl:Class ;
+                                     rdfs:subClassOf <http://w3id.org/pmd/ao/tto/ValueObject> ;
+                                     rdfs:label "Radius"@de ,
+                                                "Radius"@en ;
+                                     <http://www.w3.org/2004/02/skos/core#definition> "A line segment extending from the center of a circle or sphere to the circumference or bounding surface."@en ;
+                                     <http://w3id.org/pmd/ao/tto/definitionSource> "“Radius.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/radius. Accessed 5 Dec. 2022."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/Rectangular
+<http://w3id.org/pmd/ao/tto/Rectangular> rdf:type owl:Class ;
+                                          rdfs:subClassOf <http://w3id.org/pmd/ao/tto/Shape> ;
+                                          rdfs:label "Rechteckig"@de ,
+                                                     "Rectangular"@en ;
+                                          <http://www.w3.org/2004/02/skos/core#definition> "Geformt wie ein Rechteck."@de ,
+                                                                                           "Shaped like a rectangle."@en ;
+                                          <http://w3id.org/pmd/ao/tto/definitionSource> "“Rectangular.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/rectangular. Accessed 13 Jan. 2023."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/RegionOfInterest
+<http://w3id.org/pmd/ao/tto/RegionOfInterest> rdf:type owl:Class ;
+                                               rdfs:subClassOf <http://w3id.org/pmd/ao/tto/Object> ;
+                                               rdfs:label "Betrachteter Bereich"@de ,
+                                                          "Region of Interest"@en ;
+                                               <http://www.w3.org/2004/02/skos/core#definition> "Some region of interest in an image. You might refer to some resource of an annotation ontology."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/Regression
+<http://w3id.org/pmd/ao/tto/Regression> rdf:type owl:Class ;
+                                         rdfs:subClassOf <http://w3id.org/pmd/ao/tto/Algorithm> ;
+                                         rdfs:label "Regression"@de ,
+                                                    "Regression"@en ;
+                                         <http://www.w3.org/2004/02/skos/core#definition> """A functional relationship between two or more correlated variables that is often empirically determined from data and is used especially to predict values of one variable when given values of the others.
+Specifically : a function that yields the mean value of a random variable under the condition that one or more independent variables have specified values."""@en ;
+                                         <http://www.w3.org/2004/02/skos/core#example> "Regression of y on x is linear"@en ;
+                                         <http://w3id.org/pmd/ao/tto/definitionSource> "“Regression.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/regression. Accessed 24 Nov. 2022."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/RelatedProjectIdentifier
+<http://w3id.org/pmd/ao/tto/RelatedProjectIdentifier> rdf:type owl:Class ;
+                                                       rdfs:subClassOf <http://w3id.org/pmd/ao/tto/Identifier> ;
+                                                       rdfs:label "Identifikation Eines Verbundenen Projektes"@de ,
+                                                                  "Related Project Identifier"@en ;
+                                                       <http://www.w3.org/2004/02/skos/core#definition> "Diese Eigenschaft beschreibt einen benannten Wert, der dazu dient, zwischen Projekten zu unterscheiden, die mit dem betrachteten Projekt in Relation stehen. Zwei in Relation stehende Projekte könnten zum Beispiel ein Messprojekt sein, das Teil eines Projekts mit einem breiteren Betrachtungsbereich ist."@de ,
+                                                                                                        "This property describes a named value intended to distinguish between projects that are related to the project considered. For instance, two related projects could be a measurement project that is part of project with a broader scope."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/Roughness
+<http://w3id.org/pmd/ao/tto/Roughness> rdf:type owl:Class ;
+                                        rdfs:subClassOf <http://w3id.org/pmd/ao/tto/ValueObject> ;
+                                        rdfs:label "Oberflächenrauheit"@de ,
+                                                   "Roughness"@en ;
+                                        <http://www.w3.org/2004/02/skos/core#definition> "Die Oberflächenrauheit, oft abgekürzt als Rauheit, ist eine Komponente zur Beschreibung der Oberflächenbeschaffenheit (Oberflächentextur). Sie wird durch die Abweichungen in der Richtung des Normalenvektors einer realen Oberfläche von ihrer idealen Form quantifiziert. Sind diese Abweichungen groß, ist die Oberfläche rau (große Rauheit), sind sie klein, ist die Oberfläche glatt (geringe Rauheit)."@de ,
+                                                                                         "Surface roughness, often shortened to roughness, is a component of surface finish (surface texture). It is quantified by the deviations in the direction of the normal vector of a real surface from its ideal form. If these deviations are large, the surface is rough; if they are small, the surface is smooth."@en ;
+                                        <http://w3id.org/pmd/ao/tto/definitionSource> "http://en.wikipedia.org/wiki/Surface_roughness"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/Rp01
+<http://w3id.org/pmd/ao/tto/Rp01> rdf:type owl:Class ;
+                                   owl:equivalentClass [ rdf:type owl:Restriction ;
+                                                         owl:onProperty <http://w3id.org/pmd/ao/tto/relatesToExtension> ;
+                                                         owl:someValuesFrom [ rdf:type owl:Restriction ;
+                                                                              owl:onProperty <http://w3id.org/pmd/ao/tto/hasValue> ;
+                                                                              owl:hasValue "0.1"^^xsd:float
+                                                                            ]
+                                                       ] ;
+                                   rdfs:subClassOf <http://w3id.org/pmd/ao/tto/ProofStrengthPlasticExtension> ;
+                                   rdfs:label "Dehngrenze bei plastischer Extensometer-Dehnung Rp01"@de ,
+                                              "Proof Strength Plastic Extension Rp01"@en ;
+                                   <http://www.w3.org/2004/02/skos/core#definition> "Spannung bei einer plastischen Extensometer-Dehnung, die 0,1 Prozent der Extensometer-Messlänge entspricht"@de ,
+                                                                                    "Symbol: R_p_0.1"@en ,
+                                                                                    "stress at which the plastic extension is equal to 0.1 percent of the extensometer gauge length"@en ;
+                                   <http://w3id.org/pmd/ao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/Rp02
+<http://w3id.org/pmd/ao/tto/Rp02> rdf:type owl:Class ;
+                                   owl:equivalentClass [ rdf:type owl:Restriction ;
+                                                         owl:onProperty <http://w3id.org/pmd/ao/tto/relatesToExtension> ;
+                                                         owl:someValuesFrom [ rdf:type owl:Restriction ;
+                                                                              owl:onProperty <http://w3id.org/pmd/ao/tto/hasValue> ;
+                                                                              owl:hasValue "0.2"^^xsd:float
+                                                                            ]
+                                                       ] ;
+                                   rdfs:subClassOf <http://w3id.org/pmd/ao/tto/ProofStrengthPlasticExtension> ;
+                                   rdfs:label "Dehngrenze bei plastischer Extensometer-Dehnung Rp02"@de ,
+                                              "Proof Strength Plastic Extension Rp02"@en ;
+                                   <http://www.w3.org/2004/02/skos/core#definition> "Spannung bei einer plastischen Extensometer-Dehnung, die 0,2 Prozent der Extensometer-Messlänge entspricht"@de ,
+                                                                                    "Symbol: R_p_0.2"@en ,
+                                                                                    "stress at which the plastic extension is equal to 0.2 percent of the extensometer gauge length"@en ;
+                                   <http://w3id.org/pmd/ao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/Sample
+<http://w3id.org/pmd/ao/tto/Sample> rdf:type owl:Class ;
+                                     rdfs:subClassOf <http://w3id.org/pmd/ao/tto/EngineeredMaterial> ;
+                                     rdfs:label "Probe"@de ,
+                                                "Sample"@en ;
+                                     <http://www.w3.org/2004/02/skos/core#definition> "Portion of material, usually selected from a larger quantity of material, collected and taken away for testing"@en ;
+                                     <http://w3id.org/pmd/ao/tto/definitionSource> "ISO 18589-1:2019-11 (international standardization committee: ISO/TC 85/SC 2/WG 17)"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/SecondaryData
+<http://w3id.org/pmd/ao/tto/SecondaryData> rdf:type owl:Class ;
+                                            rdfs:subClassOf <http://w3id.org/pmd/ao/tto/DataScope> ;
+                                            rdfs:label "Secondary Data"@en ,
+                                                       "Sekundärdaten"@de ;
+                                            <http://www.w3.org/2004/02/skos/core#definition> "Characteristic values (e.g. test results) determined by equations or algorithms using primary data and metadata for a process"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/SemiCrystallineStructure
+<http://w3id.org/pmd/ao/tto/SemiCrystallineStructure> rdf:type owl:Class ;
+                                                       rdfs:subClassOf <http://w3id.org/pmd/ao/tto/MaterialStructure> ;
+                                                       rdfs:label "Semi Crystalline Structure"@en ,
+                                                                  "Semikristalline Struktur"@de ;
+                                                       <http://www.w3.org/2004/02/skos/core#definition> "Feststoffe, die eine teilkristalline Struktur aufweisen, enthalten sowohl kristalline als auch amorphe Bereiche (Domänen). Kristalline Stoffe, die keine Einkristalle, sondern Polykristalle sind, werden nicht als teilkristallin bezeichnet, auch wenn sich zwischen den Kristalliten ein dünner amorpher Film befindet."@de ,
+                                                                                                        "Solid materials exhibiting a semi-crystalline structure contain both crystalline and amorphous sections (domains). Crystalline substances that are polycrystals rather than single crystals are not designated as semicrystalline, even if there is a thin amorphous film between the crystallites."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/SequenceNumber
+<http://w3id.org/pmd/ao/tto/SequenceNumber> rdf:type owl:Class ;
+                                             rdfs:subClassOf <http://w3id.org/pmd/ao/tto/Identifier> ;
+                                             rdfs:label "Sequence Number"@en ,
+                                                        "Sequenznummer"@de ;
+                                             <http://www.w3.org/2004/02/skos/core#definition> "Strict monotonically increasing integer that indicates the position in an ordered list."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/SetPoint
+<http://w3id.org/pmd/ao/tto/SetPoint> rdf:type owl:Class ;
+                                       rdfs:subClassOf <http://w3id.org/pmd/ao/tto/ValueScope> ;
+                                       rdfs:label "Set Point"@en ,
+                                                  "Sollwert"@de ;
+                                       <http://www.w3.org/2004/02/skos/core#definition> "In cybernetics and control theory, a setpoint (SP;[1] also set point) is the desired or target value for an essential variable, or process value (PV) of a control system."@en ,
+                                                                                        "Sollwert bezeichnet allgemein den angestrebten Wert eines quantitativen Merkmales eines Systems, von dem der tatsächliche Istwert so wenig wie möglich abweichen soll. Der Sollwert wird von einem anderen System (z. B. Technik, Mensch) vorgegeben."@de ;
+                                       <http://w3id.org/pmd/ao/tto/definitionSource> "http://de.wikipedia.org/wiki/Sollwert"@de ,
+                                                                                      "http://en.wikipedia.org/wiki/Setpoint_(control_system)"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/Shape
+<http://w3id.org/pmd/ao/tto/Shape> rdf:type owl:Class ;
+                                    rdfs:subClassOf <http://w3id.org/pmd/ao/tto/ValueObject> ;
+                                    rdfs:label "Form"@de ,
+                                               "Shape"@en ;
+                                    <http://www.w3.org/2004/02/skos/core#definition> "Das sichtbare Ausstattungsmerkmal (räumliche Form oder Kontur) eines bestimmten Objektes oder einer Art von Objekt."@de ,
+                                                                                     "The visible makeup characteristic (spatial form or contour) of a particular item or kind of item."@en ;
+                                    <http://w3id.org/pmd/ao/tto/definitionSource> "“Shape.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/shape. Accessed 13 Jan. 2023."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/Slide
+<http://w3id.org/pmd/ao/tto/Slide> rdf:type owl:Class ;
+                                    rdfs:subClassOf <http://w3id.org/pmd/ao/tto/ProcessingNode> ;
+                                    rdfs:label "Schlitten"@de ,
+                                               "Slide"@en ;
+                                    <http://www.w3.org/2004/02/skos/core#definition> "A moving piece that is guided by a part along its path, providing the mount for objects."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/SlopeOfTheElasticPart
+<http://w3id.org/pmd/ao/tto/SlopeOfTheElasticPart> rdf:type owl:Class ;
+                                                    rdfs:subClassOf <http://w3id.org/pmd/ao/tto/ValueObject> ;
+                                                    rdfs:label "Slope Of The Elastic Part"@en ,
+                                                               "Steigung des elastischen Bereichs"@de ;
+                                                    <http://www.w3.org/2004/02/skos/core#definition> "Diese Eigenschaft beschreibt den Wert der Steigung des ersten linear ansteigenden Teils (\"elastischer Teil\") in der bei einem Zugversuch erhaltenen Spannungs-Dehnungs-Kurve. Im elastischen Teil der Spannungs-Dehnungs-Kurve muss der Wert der Steigung nicht unbedingt dem Elastizitätsmodul entsprechen. Dieser Wert kann mit dem Wert des Elastizitätsmoduls (nur) sehr gut übereinstimmen, wenn optimale Bedingungen herrschten."@de ,
+                                                                                                     "This property describes the value of the slope of the first linear increasing part (‘elastic part’) in the stress-percentage extension curve obtained during a tensile test. In the elastic part of the stress‐percentage extension curve, the value of the slope may not necessarily represent the modulus of elasticity. This value may closely agree with the value of the modulus of elasticity if optimal conditions were used."@en ;
+                                                    <http://w3id.org/pmd/ao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/Specimen
+<http://w3id.org/pmd/ao/tto/Specimen> rdf:type owl:Class ;
+                                       rdfs:subClassOf <http://w3id.org/pmd/ao/tto/Sample> ;
+                                       owl:disjointWith <http://w3id.org/pmd/ao/tto/TestPiece> ;
+                                       rdfs:label "Prüfling"@de ,
+                                                  "Specimen"@en ;
+                                       <http://www.w3.org/2004/02/skos/core#definition> "An object designed for a specific analysis." .
+
+
+###  http://w3id.org/pmd/ao/tto/SpecimenName
+<http://w3id.org/pmd/ao/tto/SpecimenName> rdf:type owl:Class ;
+                                           owl:equivalentClass [ owl:intersectionOf ( <http://w3id.org/pmd/ao/tto/Identifier>
+                                                                                      [ rdf:type owl:Restriction ;
+                                                                                        owl:onProperty <http://w3id.org/pmd/ao/tto/isCharacteristicOf> ;
+                                                                                        owl:someValuesFrom <http://w3id.org/pmd/ao/tto/Specimen>
+                                                                                      ]
+                                                                                    ) ;
+                                                                 rdf:type owl:Class
+                                                               ] ;
+                                           rdfs:subClassOf <http://w3id.org/pmd/ao/tto/Identifier> ;
+                                           rdfs:label "Prüfstück Name"@de ,
+                                                      "Specimen Name"@en ;
+                                           <http://www.w3.org/2004/02/skos/core#definition> "Diese Eigenschaft beschreibt die Bezeichnung eines Prüfstücks, die in der Regel von Menschen als von Menschen lesbarer Identifikator vergeben wird."@de ,
+                                                                                            "This property describes the designation of a specimen, usually given as human-readable identifier by humans."@de .
+
+
+###  http://w3id.org/pmd/ao/tto/Squared
+<http://w3id.org/pmd/ao/tto/Squared> rdf:type owl:Class ;
+                                      rdfs:subClassOf <http://w3id.org/pmd/ao/tto/Shape> ;
+                                      rdfs:label "Quadratisch"@de ,
+                                                 "Squared"@en ;
+                                      <http://www.w3.org/2004/02/skos/core#definition> "Geformt mit vier gleichen Seiten und vier rechten Winkeln."@de ,
+                                                                                       "Having four equal sides and four right angles."@en ;
+                                      <http://w3id.org/pmd/ao/tto/definitionSource> "“Square.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/square. Accessed 13 Jan. 2023."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/StartTime
+<http://w3id.org/pmd/ao/tto/StartTime> rdf:type owl:Class ;
+                                        rdfs:subClassOf <http://w3id.org/pmd/ao/tto/Time> ;
+                                        rdfs:label "Start Time"@en ,
+                                                   "Startzeit"@de ;
+                                        <http://www.w3.org/2004/02/skos/core#definition> "The date and time when the plan/recipe is supposed to be executed."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/Stiffness
+<http://w3id.org/pmd/ao/tto/Stiffness> rdf:type owl:Class ;
+                                        rdfs:subClassOf <http://w3id.org/pmd/ao/tto/ValueObject> ;
+                                        rdfs:label "Steifigkeit"@de ,
+                                                   "Stiffness"@en ;
+                                        <http://www.w3.org/2004/02/skos/core#definition> "Die Steifigkeit ist das Maß, bis zu dem ein Objekt einer Verformung als Reaktion auf eine einwirkende Kraft widersteht."@de ,
+                                                                                         "Stiffness is the extent to which an object resists deformation in response to an applied force."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/StrainRate
+<http://w3id.org/pmd/ao/tto/StrainRate> rdf:type owl:Class ;
+                                         rdfs:subClassOf <http://w3id.org/pmd/ao/tto/TestingRate> ;
+                                         rdfs:label "Dehngeschwindigkeit"@de ,
+                                                    "Strain Rate"@en ;
+                                         <http://www.w3.org/2004/02/skos/core#definition> "Symbol: e^._L_e"@en ,
+                                                                                          "Zunahme der mit einem Extensometer in der Extensometer-Messlänge gemessenen Dehnung je Zeiteinheit"@de ,
+                                                                                          "increase of strain, measured with an extensometer, in extensometer gauge length, per time"@en ;
+                                         <http://w3id.org/pmd/ao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/Stress
+<http://w3id.org/pmd/ao/tto/Stress> rdf:type owl:Class ;
+                                     owl:equivalentClass [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
+                                                                                  owl:onProperty <http://w3id.org/pmd/ao/tto/relatesTo> ;
+                                                                                  owl:someValuesFrom <http://w3id.org/pmd/ao/tto/Area>
+                                                                                ]
+                                                                                [ rdf:type owl:Restriction ;
+                                                                                  owl:onProperty <http://w3id.org/pmd/ao/tto/relatesTo> ;
+                                                                                  owl:someValuesFrom <http://w3id.org/pmd/ao/tto/Force>
+                                                                                ]
+                                                                              ) ;
+                                                           rdf:type owl:Class
+                                                         ] ;
+                                     rdfs:subClassOf <http://w3id.org/pmd/ao/tto/ValueObject> ;
+                                     rdfs:label "Spannung"@de ,
+                                                "Stress"@en ;
+                                     <http://www.w3.org/2004/02/skos/core#definition> """At any moment during the test, force divided by the original cross-sectional area, S_o, of the test piece
+
+Note: Here, all references to stress are to engineering stress."""@en ,
+                                                                                      """Dimensional Analysis: 
+ML*-1T*-2"""@en ,
+                                                                                      """Kraft zu einem beliebigen Zeitpunkt während des Versuchs dividiert durch den Anfangsquerschnitt (S_o) der Probe
+
+Anmerkung: Mit dem Begriff Spannung ist hier die technische Spannung ('Ingenieur-Spannung') gemeint."""@de ,
+                                                                                      "Symbol: R"@en ,
+                                                                                      "Units: Pa (SI), psi"@en ;
+                                     <http://w3id.org/pmd/ao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/StressRate
+<http://w3id.org/pmd/ao/tto/StressRate> rdf:type owl:Class ;
+                                         rdfs:subClassOf <http://w3id.org/pmd/ao/tto/TestingRate> ;
+                                         rdfs:label "Spannungsgeschwindigkeit"@de ,
+                                                    "Stress Rate"@en ;
+                                         <http://www.w3.org/2004/02/skos/core#definition> "Symbol: R"@en ,
+                                                                                          """Zunahme der Spannung je Zeiteinheit
+
+Anmerkung: Die Spannungsgeschwindigkeit wird nur im elastischen Bereich des Versuchs verwendet."""@de ,
+                                                                                          """increase of stress per time
+
+Note: Stress rate is only used in the elastic part of the test."""@en ;
+                                         <http://w3id.org/pmd/ao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/TemperatueMeasuringDevice
+<http://w3id.org/pmd/ao/tto/TemperatueMeasuringDevice> rdf:type owl:Class ;
+                                                        rdfs:subClassOf <http://w3id.org/pmd/ao/tto/MeasuringDevice> ;
+                                                        rdfs:label "Temperatue Measuring Device"@en ,
+                                                                   "Temperaturmesswerkzeug"@de ;
+                                                        <http://www.w3.org/2004/02/skos/core#definition> "Diese Entität beschreibt allgemein jedes Werkzeug, das zur Messung der Temperatur eines materiellen Objekts oder der Umgebung verwendet wird, z. B. ein Thermoelement und Thermometer."@de ,
+                                                                                                         "This entity generically describes any tool that is used for the measurement of the temperature of a tangible object or the environment, e.g., a thermocouple and thermometers."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/Temperature
+<http://w3id.org/pmd/ao/tto/Temperature> rdf:type owl:Class ;
+                                          rdfs:subClassOf <http://w3id.org/pmd/ao/tto/ValueObject> ;
+                                          rdfs:label "Temperatur"@de ,
+                                                     "Temperature"@en ;
+                                          <http://www.w3.org/2004/02/skos/core#definition> "The degree of hotness or coldness measured on a definite scale."@en ;
+                                          <http://w3id.org/pmd/ao/tto/definitionSource> "“Temperature.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/temperature. Accessed 25 Nov. 2022."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/TemperatureChangeDevice
+<http://w3id.org/pmd/ao/tto/TemperatureChangeDevice> rdf:type owl:Class ;
+                                                      rdfs:subClassOf <http://w3id.org/pmd/ao/tto/TemperatueMeasuringDevice> ;
+                                                      rdfs:label "Temperature Change Device"@en ,
+                                                                 "Temperaturänderungswerkzeug"@de ;
+                                                      <http://www.w3.org/2004/02/skos/core#definition> "Diese Entität beschreibt allgemein jedes Werkzeug, das zur Änderung und Einstellung der Temperatur eines materiellen Objekts oder der Umgebung verwendet wird, z. B. einen Ofen und Kühlmittel."@de ,
+                                                                                                       "This entity generically describes any tool that is used for the alteration and adjustment of the temperature of a tangible object or the environment, e.g., a furnace and cooling media."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/TemperatureChangingProcess
+<http://w3id.org/pmd/ao/tto/TemperatureChangingProcess> rdf:type owl:Class ;
+                                                         rdfs:subClassOf <http://w3id.org/pmd/ao/tto/ConditioningProcess> ;
+                                                         rdfs:label "Temperature Changing Process"@en ,
+                                                                    "Temperaturänderungsprozess"@de ;
+                                                         <http://www.w3.org/2004/02/skos/core#definition> "This properpy is used to describe a process which is run to increase or decrease the temperature of an object or a space. Usually, this involves heating or cooling devices such as furnaces or cooling media."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/TensileStrength
+<http://w3id.org/pmd/ao/tto/TensileStrength> rdf:type owl:Class ;
+                                              owl:equivalentClass [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
+                                                                                           owl:onProperty <http://w3id.org/pmd/ao/tto/relatesTo> ;
+                                                                                           owl:someValuesFrom <http://w3id.org/pmd/ao/tto/MaximumForce>
+                                                                                         ]
+                                                                                         [ rdf:type owl:Restriction ;
+                                                                                           owl:onProperty <http://w3id.org/pmd/ao/tto/relatesTo> ;
+                                                                                           owl:someValuesFrom <http://w3id.org/pmd/ao/tto/Stress>
+                                                                                         ]
+                                                                                       ) ;
+                                                                    rdf:type owl:Class
+                                                                  ] ;
+                                              rdfs:subClassOf <http://w3id.org/pmd/ao/tto/ValueObject> ;
+                                              rdfs:label "Tensile Strength"@en ,
+                                                         "Zugfestigkeit"@de ;
+                                              <http://www.w3.org/2004/02/skos/core#definition> "Spannung, die der Höchstkraft entspricht"@de ,
+                                                                                               "Symbol: R_m"@en ,
+                                                                                               "stress corresponding to the maximum force"@en ;
+                                              <http://w3id.org/pmd/ao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/TensileTest
+<http://w3id.org/pmd/ao/tto/TensileTest> rdf:type owl:Class ;
+                                          owl:equivalentClass [ rdf:type owl:Restriction ;
+                                                                owl:onProperty <http://w3id.org/pmd/ao/tto/hasParticipant> ;
+                                                                owl:someValuesFrom <http://w3id.org/pmd/ao/tto/TensileTestingMachine>
+                                                              ] ,
+                                                              [ rdf:type owl:Restriction ;
+                                                                owl:onProperty <http://w3id.org/pmd/ao/tto/hasParticipant> ;
+                                                                owl:someValuesFrom <http://w3id.org/pmd/ao/tto/TestPiece>
+                                                              ] ;
+                                          rdfs:subClassOf <http://w3id.org/pmd/ao/tto/MechanicalTestingProcess> ;
+                                          rdfs:label "Tensile Test"@en ,
+                                                     "Zugversuch"@de ;
+                                          <http://www.w3.org/2004/02/skos/core#definition> "Tensile tests (tension tests) on materials provide information on their strength, ductility as well as other characteristic values under uniaxial tensile stress."@en ,
+                                                                                           "The tensile test involves straining a test piece by tensile force, generally to fracture, for the determination of one or more mechanical properties specified by the semantically related and defined terms."@en ;
+                                          <http://w3id.org/pmd/ao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/TensileTestNode
+<http://w3id.org/pmd/ao/tto/TensileTestNode> rdf:type owl:Class ;
+                                              rdfs:subClassOf <http://w3id.org/pmd/ao/tto/ProcessingNode> ;
+                                              rdfs:label "Tensile Test Node"@en ,
+                                                         "Zugversuchsprozessknoten"@de ;
+                                              <http://www.w3.org/2004/02/skos/core#definition> "Diese Entität beschreibt einen Workflow-Bestandteil, der Werkzeuge und Geräte beinhaltet, die für die Durchführung eines Zugversuchs verwendet werden, z. B. eine Zugprüfmaschine."@de ,
+                                                                                               "This entity describes a workflow constituent that hosts tools and equipment that is used for the performance of a tensile test, e.g., a tensile test machine."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/TensileTestingMachine
+<http://w3id.org/pmd/ao/tto/TensileTestingMachine> rdf:type owl:Class ;
+                                                    rdfs:subClassOf <http://w3id.org/pmd/ao/tto/TensileTestNode> ,
+                                                                    <http://w3id.org/pmd/ao/tto/TestingMachine> ;
+                                                    rdfs:label "Tensile Testing Machine"@en ,
+                                                               "Zugprüfmaschine"@de ;
+                                                    <http://www.w3.org/2004/02/skos/core#definition> "Maschine zur Durchführung eines Zugversuches; die Regelung und Überwachung des Versuches, die Messungen und die Datenverarbeitung werden üblicherweise mithilfe eines Computers durchgeführt."@de ,
+                                                                                                     "machine to conduct a tensile test; the control and monitoring of the test, the measurements, and the data processing are usually undertaken by computer"@en ;
+                                                    <http://w3id.org/pmd/ao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/TestPiece
+<http://w3id.org/pmd/ao/tto/TestPiece> rdf:type owl:Class ;
+                                        rdfs:subClassOf <http://w3id.org/pmd/ao/tto/Sample> ;
+                                        rdfs:label "Prüfkörper"@de ,
+                                                   "Test Piece"@en ;
+                                        <http://www.w3.org/2004/02/skos/core#definition> "Part of a sample with specified dimensions, machined or un-machined, brought to a required condition for submission to a given test."@en ,
+                                                                                         "Teil einer Probe mit bestimmten Dimensionen, bearbeitet oder unbearbeitet, der in einen erforderlichen Zustand gebracht wird, um einer bestimmten Prüfung unterzogen zu werden."@de ;
+                                        <http://w3id.org/pmd/ao/tto/definitionSource> "EN 10021:2006-12 (European standardization committee: CEN/TC 459/SC 12/WG 4)"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/TestPieceClassification
+<http://w3id.org/pmd/ao/tto/TestPieceClassification> rdf:type owl:Class ;
+                                                      rdfs:subClassOf <http://w3id.org/pmd/ao/tto/TestPieceInfo> ;
+                                                      rdfs:label "Prüfkörperklassifizierung"@de ,
+                                                                 "Test Piece Classification"@en ;
+                                                      <http://www.w3.org/2004/02/skos/core#definition> "Diese Eigenschaft wird verwendet, um Informationen über einen Prüfkörper bezüglich seiner Einordnung gemäß entsprechender Normen zu liefern."@de ,
+                                                                                                       "This property is used to provide information on a test piece concerning its graduation in accordance with corresponding standards."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/TestPieceInfo
+<http://w3id.org/pmd/ao/tto/TestPieceInfo> rdf:type owl:Class ;
+                                            rdfs:subClassOf <http://w3id.org/pmd/ao/tto/ValueObject> ;
+                                            rdfs:label "Prüfkörperinformationen"@de ,
+                                                       "Test Piece Info"@en ;
+                                            <http://www.w3.org/2004/02/skos/core#definition> "Diese Eigenschaft wird verwendet, um Informationen über einen Prüfkörper zu liefern, wie z. B. seine geometrische Form, seine Klassifizierung und andere Parameter, einschließlich von Spezifikationen und Nennwerte. Die Informationen werden in Bezug auf die entsprechenden Normen bereitgestellt."@de ,
+                                                                                             "This property is used to provide information on a test piece such as its geometric shape, classification, and other parameters, including specifications and nominal values. The information is provided with respect to corresponding standards."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/TestPieceName
+<http://w3id.org/pmd/ao/tto/TestPieceName> rdf:type owl:Class ;
+                                            owl:equivalentClass [ owl:intersectionOf ( <http://w3id.org/pmd/ao/tto/Identifier>
+                                                                                       [ rdf:type owl:Restriction ;
+                                                                                         owl:onProperty <http://w3id.org/pmd/ao/tto/isCharacteristicOf> ;
+                                                                                         owl:someValuesFrom <http://w3id.org/pmd/ao/tto/TestPiece>
+                                                                                       ]
+                                                                                     ) ;
+                                                                  rdf:type owl:Class
+                                                                ] ;
+                                            rdfs:subClassOf <http://w3id.org/pmd/ao/tto/Identifier> ;
+                                            rdfs:label "Prüfkörpername"@de ,
+                                                       "Test Piece Name"@en ;
+                                            <http://www.w3.org/2004/02/skos/core#definition> "Diese Eigenschaft beschreibt die Bezeichnung eines Prüfkörpers, die in der Regel als menschenlesbarer Identifikator von Menschen vergeben wird."@de ,
+                                                                                             "This property describes the designation of a test piece, usually given as human-readable identifier by humans."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/TestingMachine
+<http://w3id.org/pmd/ao/tto/TestingMachine> rdf:type owl:Class ;
+                                             rdfs:subClassOf <http://w3id.org/pmd/ao/tto/ProcessingNode> ;
+                                             rdfs:label "Prüfmaschine"@de ,
+                                                        "Testing Machine" ;
+                                             <http://www.w3.org/2004/02/skos/core#definition> "Diese Entität beschreibt einen Prozessknoten, der für die Durchführung eines bestimmten Tests verwendet wird. Eine Prüfmaschine kann technisch komplex sein und aus mehreren Teilen bestehen."@de ,
+                                                                                              "This entity describes a processing node that is used to perform a defined test. A testing machine may be technically complex and contain several parts."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/TestingRate
+<http://w3id.org/pmd/ao/tto/TestingRate> rdf:type owl:Class ;
+                                          rdfs:subClassOf <http://w3id.org/pmd/ao/tto/ValueObject> ;
+                                          rdfs:label "Prüfgeschwindigkeit"@de ,
+                                                     "Testing Rate"@en ;
+                                          <http://www.w3.org/2004/02/skos/core#definition> "rate (resp. rates) used during the test"@en ,
+                                                                                           "während des Versuchs verwendete Geschwindigkeit(en)"@de ;
+                                          <http://w3id.org/pmd/ao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/Thermal
+<http://w3id.org/pmd/ao/tto/Thermal> rdf:type owl:Class ;
+                                      rdfs:subClassOf <http://w3id.org/pmd/ao/tto/MaterialProperty> ;
+                                      rdfs:label "Thermal"@en ,
+                                                 "Thermisch"@de ;
+                                      <http://www.w3.org/2004/02/skos/core#definition> "Thermal is relating to, or caused by heat. Here specifically to the thermal properties of a material."@en ,
+                                                                                       "Thermisch bedeutet in Bezug auf oder verursacht durch Wärme. Hier speziell auf die thermischen Eigenschaften eines Materials."@de ;
+                                      <http://w3id.org/pmd/ao/tto/definitionSource> "“Thermal.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/thermal. Accessed 13 Jan. 2023."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/Thermocouple
+<http://w3id.org/pmd/ao/tto/Thermocouple> rdf:type owl:Class ;
+                                           rdfs:subClassOf <http://w3id.org/pmd/ao/tto/MeasuringDevice> ;
+                                           rdfs:label "Thermocouple"@en ,
+                                                      "Thermoelement"@de ;
+                                           <http://www.w3.org/2004/02/skos/core#definition> "A device for measuring temperature in which a pair of wires of dissimilar metals (such as copper and iron) are joined and the free ends of the wires are connected to an instrument (such as a voltmeter) that measures the difference in potential created at the junction of the two metals."@en ,
+                                                                                            "Ein Gerät zur Temperaturmessung, bei dem ein Paar Drähte aus unterschiedlichen Metallen (z. B. Kupfer und Eisen) verbunden und die freien Enden der Drähte mit einem Instrument (z. B. einem Voltmeter) verbunden werden, das die an der Verbindungsstelle erzeugte der beiden Metalle Potentialdifferenz misst ."@de ;
+                                           <http://w3id.org/pmd/ao/tto/definitionSource> "“Thermocouple.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/thermocouple. Accessed 13 Jan. 2023."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/ThicknessAfterFracture
+<http://w3id.org/pmd/ao/tto/ThicknessAfterFracture> rdf:type owl:Class ;
+                                                     rdfs:subClassOf <http://w3id.org/pmd/ao/tto/Length> ;
+                                                     rdfs:label "End-Dicke"@de ,
+                                                                "Thickness After Fracture"@en ;
+                                                     <http://www.w3.org/2004/02/skos/core#definition> "Diese Eigenschaft beschreibt die gemessene Dimension in einer Richtung eines Prüfstücks, wie sie vor der Prüfung gemessen wurde."@de ,
+                                                                                                      "This property describes the measured dimension in one direction of a test piece, as measured after the test."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/Time
+<http://w3id.org/pmd/ao/tto/Time> rdf:type owl:Class ;
+                                   rdfs:subClassOf <http://w3id.org/pmd/ao/tto/ValueObject> ;
+                                   rdfs:label "Time"@en ,
+                                              "Zeit"@de ;
+                                   <http://www.w3.org/2004/02/skos/core#definition> "A nonspatial continuum that is measured in terms of events which succeed one another from past through present to future."@en ;
+                                   <http://w3id.org/pmd/ao/tto/definitionSource> "“Time.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/time. Accessed 25 Nov. 2022."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/TransformativeAnalysisProcess
+<http://w3id.org/pmd/ao/tto/TransformativeAnalysisProcess> rdf:type owl:Class ;
+                                                            rdfs:subClassOf <http://w3id.org/pmd/ao/tto/AnalysingProcess> ;
+                                                            rdfs:label "Transformative Analysis Process"@en ,
+                                                                       "Transformativer Analyseprozess"@de ;
+                                                            <http://www.w3.org/2004/02/skos/core#definition> "An analysis process that is also a transformative process"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/TypeGaugeLengthMarks
+<http://w3id.org/pmd/ao/tto/TypeGaugeLengthMarks> rdf:type owl:Class ;
+                                                   rdfs:subClassOf <http://w3id.org/pmd/ao/tto/TestPieceInfo> ;
+                                                   rdfs:label "Typ Der Messlängenmarkierungen"@de ,
+                                                              "Type Gauge Length Marks"@en ;
+                                                   <http://www.w3.org/2004/02/skos/core#definition> "Diese Eigenschaft wird verwendet, um die sichtbaren Markierungen zu beschreiben, die in der Regel während eines Zugversuchs zur Messung der Dehnung an den Prüfkörpern angebracht werden."@de ,
+                                                                                                    "This property is used to describe the visible markers usually attached to test pieces during a tensile test for elongation / extension measurements."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/UpperYieldStrength
+<http://w3id.org/pmd/ao/tto/UpperYieldStrength> rdf:type owl:Class ;
+                                                 owl:equivalentClass [ rdf:type owl:Restriction ;
+                                                                       owl:onProperty <http://w3id.org/pmd/ao/tto/relatesTo> ;
+                                                                       owl:someValuesFrom <http://w3id.org/pmd/ao/tto/Stress>
+                                                                     ] ;
+                                                 rdfs:subClassOf <http://w3id.org/pmd/ao/tto/YieldStrength> ;
+                                                 rdfs:label "Obere Streckgrenze"@de ,
+                                                            "Upper Yield Strength"@en ;
+                                                 <http://www.w3.org/2004/02/skos/core#definition> "Symbol: R_eH"@en ,
+                                                                                                  "höchste Spannung, bevor der erste Kraftabfall auftritt"@de ,
+                                                                                                  "maximum value of stress prior to the first decrease in force"@en ;
+                                                 <http://w3id.org/pmd/ao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/ValueObject
+<http://w3id.org/pmd/ao/tto/ValueObject> rdf:type owl:Class ;
+                                          owl:equivalentClass [ rdf:type owl:Class ;
+                                                                owl:unionOf ( <http://w3id.org/pmd/ao/tto/Metadata>
+                                                                              [ owl:intersectionOf ( [ rdf:type owl:Class ;
+                                                                                                       owl:unionOf ( <http://w3id.org/pmd/ao/tto/Measurement>
+                                                                                                                     <http://w3id.org/pmd/ao/tto/SetPoint>
+                                                                                                                   )
+                                                                                                     ]
+                                                                                                     [ rdf:type owl:Class ;
+                                                                                                       owl:unionOf ( <http://w3id.org/pmd/ao/tto/PrimaryData>
+                                                                                                                     <http://w3id.org/pmd/ao/tto/SecondaryData>
+                                                                                                                   )
+                                                                                                     ]
+                                                                                                   ) ;
+                                                                                rdf:type owl:Class
+                                                                              ]
+                                                                            )
+                                                              ] ;
+                                          rdfs:subClassOf <http://www.w3.org/ns/prov#Entity> ;
+                                          rdfs:label "Value Object"@en ,
+                                                     "Wertobjekt"@de ;
+                                          <http://www.w3.org/2004/02/skos/core#definition> """A :ValueObject is a simple entity which represents a specific value. This value can be a numerical, textual, or a more complex data structure. If a literal value is to be specified, the :hasValue datatype property has to be used. In cases where the value is represented by a resource (e.g. URI), the :hasResource object property has to be used.
+
+A value object, respectively its value, is always associated with an entity of type :Process, :ProcessNode, or :Object (e.g. :Specimen). The value is meant to be a charactaristic of the associated entity. To express this association it is indended to use the :hasParticipant object property.
+
+A value object might also refer to a certain unit. The :hasUnit property might be used (e.g. with QUDT ontology).
+
+Instances of a value object might be specified as a specific Parameter, namely a SetPoint (nominal value), or Measurement. With :Setpoint the intend is to express, that the value is meant to be some preset, setting or nominal value. :Measurement expresses, that the value has been measured or determined somehow (see example).
+
+Instances of a value object might also be specified in a specific DataScope (:Metadata, :PrimaryData, :SecondaryData)."""@en ;
+                                          <http://www.w3.org/2004/02/skos/core#example> """- the length of a specimen
+- the model number of a machine
+- a person involved in a process
+- a force on an object"""@en ,
+                                                                                        """:Length rdfs:subClass :ValueObject .
+ex:vo1 a :Length .
+ex:vo1 a :Measurement .
+ex:vo1 a :PrimaryData .
+ex:vo1 :hasUnit qudt:MilliM . 
+ex:vo1 :hasValue \"123.45\"
+ex:spec1 a :Specimen .
+ex:spec1 :hasCharacteristic ex:vo1 ."""@en ,
+                                                                                        "The length of a specimen, which has been measured as primary data. Its actual value is 123.45 millimeters."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/ValueScope
+<http://w3id.org/pmd/ao/tto/ValueScope> rdf:type owl:Class ;
+                                         rdfs:subClassOf <http://www.w3.org/ns/prov#Entity> ;
+                                         rdfs:label "Value Scope"@en ,
+                                                    "Wertekategorie"@de ;
+                                         <http://www.w3.org/2004/02/skos/core#definition> "Any of a set of physical properties whose values determine the characteristics or behavior of something."@en ;
+                                         <http://w3id.org/pmd/ao/tto/definitionSource> "“Parameter.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/parameter. Accessed 25 Nov. 2022."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/VanderwaalsBond
+<http://w3id.org/pmd/ao/tto/VanderwaalsBond> rdf:type owl:Class ;
+                                              rdfs:subClassOf <http://w3id.org/pmd/ao/tto/BondingType> ;
+                                              rdfs:label "Van der Waals Bindung"@de ,
+                                                         "Vanderwaals Bond"@en ;
+                                              <http://www.w3.org/2004/02/skos/core#definition> "Die Van-der-Waals-Bindung ist durch die relativ schwachen Anziehungskräfte gegeben, die auf neutrale Atome und Moleküle wirken und die aufgrund der elektrischen Polarisierung entstehen, die in jedem der Teilchen durch die Anwesenheit anderer Teilchen induziert wird."@de ,
+                                                                                               "Van der Waals bond is given by the relatively weak attractive forces that act on neutral atoms and molecules and that arise because of the electric polarization induced in each of the particles by the presence of other particles."@en ;
+                                              <http://w3id.org/pmd/ao/tto/definitionSource> "“Van der Waals forces.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/van%20der%20Waals%20forces. Accessed 13 Jan. 2023."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/Weight
+<http://w3id.org/pmd/ao/tto/Weight> rdf:type owl:Class ;
+                                     rdfs:subClassOf <http://w3id.org/pmd/ao/tto/ValueObject> ;
+                                     rdfs:label "Gewicht"@de ,
+                                                "Weight"@en ;
+                                     <http://www.w3.org/2004/02/skos/core#definition> "The force with which a body is attracted toward the earth or a celestial body by gravitation and which is equal to the product of the mass and the local gravitational acceleration."@en ;
+                                     <http://w3id.org/pmd/ao/tto/definitionSource> "“Weight.” Merriam-Webster.com Dictionary, Merriam-Webster, http://www.merriam-webster.com/dictionary/weight. Accessed 5 Dec. 2022."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/Width
+<http://w3id.org/pmd/ao/tto/Width> rdf:type owl:Class ;
+                                    rdfs:subClassOf <http://w3id.org/pmd/ao/tto/ValueObject> ;
+                                    rdfs:label "Breite"@de ,
+                                               "Width"@en ;
+                                    <http://www.w3.org/2004/02/skos/core#definition> "Diese Eigenschaft bezeichnet eine horizontale Messung, die im rechten Winkel zur Länge eines Objekts vorgenommen wird."@de ,
+                                                                                     "This property describes a horizontal measurement of an object taken at right angles to the length of the object."@en ;
+                                    <http://w3id.org/pmd/ao/tto/definitionSource> "http://www.merriam-webster.com/dictionary/width"@en .
+
+
+###  http://w3id.org/pmd/ao/tto/WidthAfterFracture
+<http://w3id.org/pmd/ao/tto/WidthAfterFracture> rdf:type owl:Class ;
+                                                 rdfs:subClassOf <http://w3id.org/pmd/ao/tto/Width> ;
+                                                 rdfs:label "End-Breite"@de ,
+                                                            "Width After Fracture"@en ;
+                                                 <http://www.w3.org/2004/02/skos/core#definition> "Diese Eigenschaft beschreibt eine horizontale Messung eines Objekts (Prüfkörpers) im rechten Winkel zur Länge des Objekts (Prüfkörpers), wie sie nach einer Prüfung gemessen wird."@de ,
+                                                                                                  "This property describes a horizontal measurement of an object (test piece) taken at right angles to the length of the object (test piece), as measured after a test."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/WorkingRange
+<http://w3id.org/pmd/ao/tto/WorkingRange> rdf:type owl:Class ;
+                                           rdfs:subClassOf <http://w3id.org/pmd/ao/tto/ValueObject> ;
+                                           rdfs:label "Arbeitsbereich"@de ,
+                                                      "Working Range"@en ;
+                                           <http://www.w3.org/2004/02/skos/core#definition> "Diese Eigenschaft beschreibt den Bereich zwischen den Grenzen, innerhalb derer ein Prozessknoten (z. B. eine Maschine) für ihren vorgesehenen Zweck verwendet werden kann, ausgedrückt durch die Angabe der in Rede stehenden unteren und oberen Bereichswerte."@de ,
+                                                                                            "This property describes the region between the limits within which a process node (e.g., a machine) is capable of being used for its intended purpose, expressed by stating the lower and upper range values of interest."@en .
+
+
+###  http://w3id.org/pmd/ao/tto/YieldStrength
+<http://w3id.org/pmd/ao/tto/YieldStrength> rdf:type owl:Class ;
+                                            owl:equivalentClass [ rdf:type owl:Restriction ;
+                                                                  owl:onProperty <http://w3id.org/pmd/ao/tto/relatesTo> ;
+                                                                  owl:someValuesFrom <http://w3id.org/pmd/ao/tto/Stress>
+                                                                ] ;
+                                            rdfs:subClassOf <http://w3id.org/pmd/ao/tto/ValueObject> ;
+                                            rdfs:label "Streckgrenze"@de ,
+                                                       "Yield Strength"@en ;
+                                            <http://www.w3.org/2004/02/skos/core#definition> "Wenn der metallische Werkstoff diese Eigenschaft aufweist: die Spannung zu einem bestimmten Zeitpunkt während des Versuchs bei dem eine plastische Verformung ohne Zunahme der Kraft auftritt"@de ,
+                                                                                             "when the metallic material exhibits a yield phenomenon, stress corresponding to the point reached during the test at which plastic deformation occurs without any increase in the force"@en ;
+                                            <http://w3id.org/pmd/ao/tto/definitionSource> "DIN EN ISO 6892-1:2019"@en .
+
+
 [ sdo:affiliation [ sdo:name "Bundesanstalt für Materialforschung und -prüfung (BAM)" ;
                     sdo:url "http://www.bam.de/Navigation/DE/Home/home.html"^^xsd:anyURI
                   ] ;
@@ -2794,4 +2794,4 @@ ex:spec1 :hasCharacteristic ex:vo1 ."""@en ,
                                   "http://doi.org/10.14454/3w3z-sa82" .
 
 
-###  Generated by the OWL API (version 4.5.9.2019-02-01T07:24:44Z) https://github.com/owlcs/owlapi
+###  Generated by the OWL API (version 4.5.9.2019-02-01T07:24:44Z) http://github.com/owlcs/owlapi

--- a/tensile_test_ontology_TTO/pmdao_TTO_data_mapping_example.ttl
+++ b/tensile_test_ontology_TTO/pmdao_TTO_data_mapping_example.ttl
@@ -1,11 +1,11 @@
-@prefix base: <http://material-digital.de/pmdco/> .
+@prefix base: <http://w3id.org/pmd/co/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
-@prefix ns1: <http://material-digital.de/pmdco/> .
+@prefix ns1: <http://w3id.org/pmd/co/> .
 @prefix ns2: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix tte: <http://material-digital.de/pmdao/tte/> .
+@prefix tte: <http://w3id.org/pmd/ao/tte/> .
 @prefix unit: <http://qudt.org/vocab/unit/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 


### PR DESCRIPTION
Ontology IRIs were changed from http://material-digital.de/pmdco/ to http://w3id.org/pmd/co/ and http://material-digital.de/pmdao/tto to http://w3id.org/pmd/ao/tto, respectively due to namespace convention (see https://github.com/materialdigital/core-ontology/issues/17).