### PR TITLE
Create pmd_pgo.ttl

### DIFF
--- a/precipitate_geometry_ontology_PGO/catalog-v001.xml
+++ b/precipitate_geometry_ontology_PGO/catalog-v001.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+    <uri id="Imports Wizard Entry" name="https://w3id.org/pmd/mo" uri="https://raw.githubusercontent.com/materialdigital/core-ontology/mo-module/pmd_mo.ttl"/>
+    <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base=""/>
+</catalog>

--- a/precipitate_geometry_ontology_PGO/pmd_pgo.ttl
+++ b/precipitate_geometry_ontology_PGO/pmd_pgo.ttl
@@ -1,0 +1,123 @@
+@prefix : <http://www.semanticweb.org/mschilli/ontologies/2023/9/untitled-ontology-275/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@base <http://www.semanticweb.org/mschilli/ontologies/2023/9/untitled-ontology-275/> .
+
+<https://w3id.org/pmd/pgo> rdf:type owl:Ontology ;
+                            owl:versionIRI <https://w3id.org/pmd/pgo/1.0.0> ;
+                            owl:imports <https://w3id.org/pmd/co/2.0.5> ;
+                            <http://purl.org/dc/elements/1.1/creator> <https://orcid.org/0000-0002-3717-7104> ,
+                                                                      <https://orcid.org/0000-0002-7094-5371> ;
+                            <http://purl.org/dc/elements/1.1/license> <http://creativecommons.org/licenses/by/4.0> ;
+                            rdfs:label "Platform MaterialDigital - Precipitate Geometry Ontology (PGO)"@en ;
+                            <http://www.w3.org/2004/02/skos/core#definition> "This ontology is part of the \"Orowan Demonstrator\""@en .
+
+#################################################################
+#    Classes
+#################################################################
+
+###  http://w3id.org/pmd/co/AveragePrecipitateDistance
+<http://w3id.org/pmd/co/AveragePrecipitateDistance> rdf:type owl:Class ;
+                                                    rdfs:subClassOf <http://w3id.org/pmd/co/PrecipitateDistance> ;
+                                                    rdfs:isDefinedBy <https://w3id.org/pmd/co> ;
+                                                    rdfs:label "Average Precipitate Distance"@en ,
+                                                               "Mittlerer Ausscheidungsabstand"@de ;
+                                                    <http://www.w3.org/2004/02/skos/core#definition> "Als Subklasse der Ausscheidungsabstand wird der mittlere Ausscheidungsabstand aus mehreren Ausscheidungsabständen ermittelt, z. B. durch die Delauney-Triangulation."@de ,
+                                                                                                     "As a subclass of precipitate distance, the average precipitate distance is determined from several precipitate distances via, e.g., the Delauney triangulation."@en .
+
+
+###  http://w3id.org/pmd/co/CalibrationFactor
+<http://w3id.org/pmd/co/CalibrationFactor> rdf:type owl:Class ;
+                                           rdfs:subClassOf <https://w3id.org/pmd/co/ValueObject> ;
+                                           rdfs:isDefinedBy <https://w3id.org/pmd/co> ;
+                                           <http://www.w3.org/2004/02/skos/core#definition> "Als Subklasse des Values Objects bietet der Kalibrierungsfaktor einen Umrechnungsfaktor von Pixeln in reale Dimensionen, der die Skalierung von Bildern in metrische Einheiten ermöglicht."@de ,
+                                                                                            "As a subclass of value object, the calibration factor provides a pixel-to-real-distance conversion factor, that allows image scaling to metric units."@en ,
+                                                                                            "Calibration Factor"@en ,
+                                                                                            "Kalibrierungsfaktor"@de .
+
+
+###  http://w3id.org/pmd/co/DarkFieldImage
+<http://w3id.org/pmd/co/DarkFieldImage> rdf:type owl:Class ;
+                                        rdfs:subClassOf <https://w3id.org/pmd/co/Image> ;
+                                        rdfs:isDefinedBy <https://w3id.org/pmd/co> ;
+                                        rdfs:label "Dark-field Image"@en ,
+                                                   "Dunkelfeldbild"@de ;
+                                        <http://www.w3.org/2004/02/skos/core#definition> "Als Subklasse des Bildes wird das Dunkelfeldbild mit einem hochauflösenden Transmissionselektronenmikroskop (HR-TEM) erzeugt."@de ,
+                                                                                         "As a subclass of image, the dark-field image is generated from a high-resolution transmission electron microscope (HR-TEM)."@en .
+
+
+###  http://w3id.org/pmd/co/ImageAnalysisProcess
+<http://w3id.org/pmd/co/ImageAnalysisProcess> rdf:type owl:Class ;
+                                              rdfs:subClassOf <https://w3id.org/pmd/co/NonTransformativeAnalysisProcess> ;
+                                              rdfs:isDefinedBy <https://w3id.org/pmd/co> ;
+                                              rdfs:label "Bildanalyse-Prozess"@de ,
+                                                         "Image Analysis Process"@en ;
+                                              <http://www.w3.org/2004/02/skos/core#definition> "Als Unterklasse eines nicht-transformativen Analyseverfahrens ist das Bildanalyseverfahren ein Prozess, mit dem nützliche Informationen, wie z. B. Koordinaten von Ausscheidungen in metallischen Legierungen und deren Abständen, aus einem Bild extrahiert und für die weitere Verwendung interpretiert werden."@de ,
+                                                                                               "As subclass of a non-transformative analysis process, the image analysis process is a process by which useful information, such as precipitate coordinates and their distances, are extracted from an image and interpreted for further application."@en .
+
+
+###  http://w3id.org/pmd/co/Particle
+<http://w3id.org/pmd/co/Particle> rdf:type owl:Class ;
+                                  rdfs:subClassOf <https://w3id.org/pmd/co/Object> ;
+                                  rdfs:isDefinedBy <https://w3id.org/pmd/co> ;
+                                  rdfs:label "Particle"@en ,
+                                             "Partikel"@de ;
+                                  <http://www.w3.org/2004/02/skos/core#definition> "Als eine Subklasse von Objekt ist ein Partikel ein kleines, lokalisiertes Objekt, das durch mehrere physikalische oder chemische Eigenschaften wie Volumen, Dichte oder Masse beschrieben werden kann."@de ,
+                                                                                   "As a subclass of object, a particle is a small localized object which can be described by several physical or chemical properties, such as volume, density, or mass."@en ;
+                                  <https://w3id.org/pmd/co/definitionSource> <https://en.wikipedia.org/wiki/Particle> .
+
+
+###  http://w3id.org/pmd/co/ParticleArea
+<http://w3id.org/pmd/co/ParticleArea> rdf:type owl:Class ;
+                                      rdfs:subClassOf <https://w3id.org/pmd/co/Area> ;
+                                      rdfs:isDefinedBy <https://w3id.org/pmd/co> ;
+                                      rdfs:label "Particle Area"@en ,
+                                                 "Partikelfläche"@de ;
+                                      <http://www.w3.org/2004/02/skos/core#definition> "Als Subklasse der Fläche ist die Partikelfläche ein Maß,welches zum Vergleich von Partikelgrößen verwendet wird. In der Regel wird für Ausscheidungspartikel eine kreisförmige Näherung verwendet."@de ,
+                                                                                       "As a subclass of area, particle area is a measure used to compare particle sizes. Usually, a circular approximation is used for precipitating particles."@en .
+
+
+###  http://w3id.org/pmd/co/ParticleRadius
+<http://w3id.org/pmd/co/ParticleRadius> rdf:type owl:Class ;
+                                        rdfs:subClassOf <https://w3id.org/pmd/co/Radius> ;
+                                        rdfs:isDefinedBy <https://w3id.org/pmd/co> ;
+                                        rdfs:label "Particle Radius"@en ,
+                                                   "Partikelradius"@de ;
+                                        <http://www.w3.org/2004/02/skos/core#definition> "Als Subklasse des Radius ist der Partikelradius ein Maß, das für eine spezifische Korrelation der Partikelgröße verwendet wird. Der Partikelradius wird in der Regel aus der kreisförmigen Annäherung der Partikelfläche berechnet."@de ,
+                                                                                         "As a subclass of radius, particle radius is a measure used to perform a specific particle size correlation. The particle radius is usually obtained from the circular approximation of the particle area."@en .
+
+
+###  http://w3id.org/pmd/co/Precipitate
+<http://w3id.org/pmd/co/Precipitate> rdf:type owl:Class ;
+                                     rdfs:subClassOf <http://w3id.org/pmd/co/Particle> ;
+                                     rdfs:isDefinedBy <https://w3id.org/pmd/co> ;
+                                     rdfs:label "Ausscheidung"@de ,
+                                                "Precipitate"@en ;
+                                     <http://www.w3.org/2004/02/skos/core#definition> "Als Subklasse von Particle sind Ausscheidungen fein verteilte metastabile Phasen (z. B. intermetallischen Verbindungen), die als wirksame Hindernisse für Versetzungsbewegungen in aushärtbaren metallischen Legierungen durch gezielte Wärmenbehandlungen erzeugt werden."@de ,
+                                                                                      "As a subclass of particle, precipitates are finely distributed metastable phases (e.g., intermetallic compounds) that are created as effective obstacles to dislocation motion in age-hardenable metallic alloys by specific heat treatments."@en .
+
+
+###  http://w3id.org/pmd/co/PrecipitateDistance
+<http://w3id.org/pmd/co/PrecipitateDistance> rdf:type owl:Class ;
+                                             rdfs:subClassOf <https://w3id.org/pmd/co/Distance> ;
+                                             rdfs:isDefinedBy <https://w3id.org/pmd/co> ;
+                                             rdfs:label "Ausscheidungsabstand"@de ,
+                                                        "Precipitate Distance"@en ;
+                                             <http://www.w3.org/2004/02/skos/core#definition> "Als Subklasse des Abstands ist der Ausscheidungsabstand ein Maß für den Abstand zwischen zwei Ausscheidungen in metallischen Legierungen. Üblicherweise wird dieser Abstand aus der Analyse von Dunkelfeld-TEM-Bildern gewonnen und in Nanometern angegeben."@de ,
+                                                                                              "As a subclass of distance, the precipitate distance is a measure of the distance between two precipitates. Usually, this distance is obtained from analysing dark-field TEM images and given in nanometers."@en .
+
+
+###  http://w3id.org/pmd/co/PrecipitateNumber
+<http://w3id.org/pmd/co/PrecipitateNumber> rdf:type owl:Class ;
+                                           rdfs:subClassOf <https://w3id.org/pmd/co/Index> ;
+                                           rdfs:isDefinedBy <https://w3id.org/pmd/co> ,
+                                                            "Die Ausscheidungsnummer ermöglicht die eindeutige Zuordnung der gemessenen Eigenschaften zu einem bestimmten Ausscheidung."@de ,
+                                                            "The precipitate number enables the explicit assignment of measured properties to a specific precipitate."@en ;
+                                           rdfs:label "Ausscheidungsnummer"@de ,
+                                                      "Particle Number"@en .
+
+
+###  Generated by the OWL API (version 4.5.25.2023-02-15T19:15:49Z) https://github.com/owlcs/owlapi

--- a/tensile_test_ontology_TTO/pmd_tto.ttl
+++ b/tensile_test_ontology_TTO/pmd_tto.ttl
@@ -4,7 +4,7 @@
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@base <https://w3id.org/pmd/tto> .
+@base <https://w3id.org/pmd/co/> .
 
 <https://w3id.org/pmd/tto> rdf:type owl:Ontology ;
                             owl:imports <https://w3id.org/pmd/co> ;
@@ -14,10 +14,10 @@
                                                                       <https://orcid.org/0000-0002-9014-2920> ,
                                                                       <https://orcid.org/0000-0003-4971-3645> ;
                             <http://purl.org/dc/elements/1.1/license> <http://creativecommons.org/licenses/by/4.0/> ;
-                            <http://purl.org/dc/terms/bibliographicCitation> "Markus Schilling, Bernd Bayerlein, Henk Birkholz, Philipp von Hartrott, Jörg Waitelonis. (June 07th, 2023) TTO: Tensile Test Ontology. Version 2.0.0, https://w3id.org/pmd/co"@en ;
-                            <http://purl.org/dc/terms/created> "2023-06-07"@en ;
+                            <http://purl.org/dc/terms/bibliographicCitation> "Markus Schilling, Bernd Bayerlein, Henk Birkholz, Philipp von Hartrott, Jörg Waitelonis. (July 14th, 2023) TTO: Tensile Test Ontology. Version 2.0.0, https://w3id.org/pmd/co"@en ;
+                            <http://purl.org/dc/terms/created> "2023-07-14"@en ;
                             <http://purl.org/dc/terms/title> "Tensile Test Ontology (TTO)"@en ;
-                            owl:versionInfo "2.0.0" ;
+                            owl:versionInfo "2.0.1" ;
                             <http://www.w3.org/2004/02/skos/core#definition> """This is the stable version of the PMD ontology module of the tensile test (Tensile Test Ontology - TTO) as developed on the basis of the standard ISO 6892-1: Metallic materials - Tensile Testing - Part 1: Method of test at room temperature.
 
 The TTO was developed in the frame of the PMD project. The TTO provides conceptualizations valid for the description of tensile test and corresponding data in accordance with the respective standard. By using TTO for storing tensile test data, all data will be well structured and based on a common vocabulary agreed on by an expert group (generation of FAIR data) which will lead to enhanced data interoperability. This comprises several data categories such as primary data, secondary data and metadata. Data will be human and machine readable. The usage of TTO facilitates data retrieval and downstream usage. Due to a close connection to the mid-level PMD core ontology (PMDco), the interoperability of tensile test data is enhanced and querying in combination with other aspects and data within the broad field of material science and engineering (MSE) is facilitated.
@@ -318,6 +318,13 @@ Note: The concept of parallel length is replaced by the concept of distance betw
                                    :definitionSource "DIN EN ISO 6892-1:2019"@en .
 
 
+###  https://w3id.org/pmd/co/PercentageExtension
+:PercentageExtension owl:equivalentClass [ rdf:type owl:Restriction ;
+                                           owl:onProperty :relatesTo ;
+                                           owl:someValuesFrom :ExtensometerGaugeLength
+                                         ] .
+
+
 ###  https://w3id.org/pmd/co/PercentagePermanentElongation
 :PercentagePermanentElongation rdf:type owl:Class ;
                                owl:equivalentClass [ rdf:type owl:Restriction ;
@@ -464,6 +471,13 @@ Note: The concept of parallel length is replaced by the concept of distance betw
 
 ###  https://w3id.org/pmd/co/ProofStrengthPlasticExtension
 :ProofStrengthPlasticExtension rdf:type owl:Class ;
+                               owl:equivalentClass [ rdf:type owl:Restriction ;
+                                                     owl:onProperty :relatesToExtension ;
+                                                     owl:someValuesFrom [ rdf:type owl:Restriction ;
+                                                                          owl:onProperty <http://www.w3.org/ns/prov#value> ;
+                                                                          owl:someValuesFrom xsd:float
+                                                                        ]
+                                                   ] ;
                                rdfs:subClassOf :ProofStrength ;
                                rdfs:isDefinedBy <https://w3id.org/pmd/tto> ;
                                rdfs:label "Dehngrenze bei plastischer Extensometer-Dehnung"@de ,
@@ -502,6 +516,13 @@ Note: A suffix is added to the subscript to indicate the prescribed percentage, 
 
 ###  https://w3id.org/pmd/co/Rp01
 :Rp01 rdf:type owl:Class ;
+      owl:equivalentClass [ rdf:type owl:Restriction ;
+                            owl:onProperty :relatesToExtension ;
+                            owl:someValuesFrom [ rdf:type owl:Restriction ;
+                                                 owl:onProperty <http://www.w3.org/ns/prov#value> ;
+                                                 owl:hasValue "0.1"^^xsd:float
+                                               ]
+                          ] ;
       rdfs:subClassOf :ProofStrengthPlasticExtension ;
       rdfs:isDefinedBy <https://w3id.org/pmd/tto> ;
       rdfs:label "Dehngrenze bei plastischer Extensometer-Dehnung Rp01"@de ,
@@ -514,6 +535,13 @@ Note: A suffix is added to the subscript to indicate the prescribed percentage, 
 
 ###  https://w3id.org/pmd/co/Rp02
 :Rp02 rdf:type owl:Class ;
+      owl:equivalentClass [ rdf:type owl:Restriction ;
+                            owl:onProperty :relatesToExtension ;
+                            owl:someValuesFrom [ rdf:type owl:Restriction ;
+                                                 owl:onProperty <http://www.w3.org/ns/prov#value> ;
+                                                 owl:hasValue "0.2"^^xsd:float
+                                               ]
+                          ] ;
       rdfs:subClassOf :ProofStrengthPlasticExtension ;
       rdfs:isDefinedBy <https://w3id.org/pmd/tto> ;
       rdfs:label "Dehngrenze bei plastischer Extensometer-Dehnung Rp02"@de ,
@@ -712,4 +740,4 @@ Note: Stress rate is only used in the elastic part of the test."""@en ;
                :definitionSource "DIN EN ISO 6892-1:2019"@en .
 
 
-###  Generated by the OWL API (version 4.5.9.2019-02-01T07:24:44Z) https://github.com/owlcs/owlapi
+###  Generated by the OWL API (version 4.5.25.2023-02-15T19:15:49Z) https://github.com/owlcs/owlapi


### PR DESCRIPTION
Classes were added to the precipitate geometry ontology (PGO) that is used to describe the analysis of precipitates in metallic alloys.